### PR TITLE
Publish to npm ci

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -1,8 +1,9 @@
 name: 'publish to npm'
 
 on:
-  workflow_dispatch:
-  
+  release:
+    types: [published]
+
 jobs:  
   publish-to-npm:
     name: 'Publish to NPM'

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -1,0 +1,20 @@
+name: 'publish to npm'
+
+on:
+  workflow_dispatch:
+  
+jobs:  
+  publish-to-npm:
+    name: 'Publish to NPM'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - run: npm run build
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
Adding new CI workflow to automatically publish to npm. 

TODO: need to set Github private variable called NPM_TOKEN. If someone here wants to add it (the token is in 1pass as "npm token CI") or alternatively make me an admin on this repo, I can do it too 