### PR TITLE
fix(Multisig): transferOperatorship using operatorEpoch

### DIFF
--- a/src/AxelarGatewayMultisig.sol
+++ b/src/AxelarGatewayMultisig.sol
@@ -404,11 +404,10 @@ contract AxelarGatewayMultisig is IAxelarGatewayMultisig, AxelarGateway {
     function transferOperatorship(bytes calldata params, bytes32) external onlySelf {
         (address[] memory newOperators, uint256 newThreshold) = abi.decode(params, (address[], uint256));
 
-        uint256 ownerEpoch = _ownerEpoch();
-
-        emit OperatorshipTransferred(operators(), _getOperatorThreshold(ownerEpoch), newOperators, newThreshold);
-
         uint256 operatorEpoch = _operatorEpoch();
+
+        emit OperatorshipTransferred(operators(), _getOperatorThreshold(operatorEpoch), newOperators, newThreshold);
+
         _setOperatorEpoch(++operatorEpoch);
         _setOperators(operatorEpoch, newOperators, newThreshold);
     }

--- a/test/AxelarGatewayMultisig.js
+++ b/test/AxelarGatewayMultisig.js
@@ -600,7 +600,7 @@ describe('AxelarGatewayMultisig', () => {
 
     describe('command transferOwnership', () => {
       it('should owners to transfer ownership', async () => {
-        const makeTransferCommand = newThreshold =>
+        const makeTransferCommand = (newThreshold) =>
           arrayify(
             defaultAbiCoder.encode(
               ['uint256', 'uint256', 'bytes32[]', 'string[]', 'bytes[]'],
@@ -619,7 +619,10 @@ describe('AxelarGatewayMultisig', () => {
             ),
           );
 
-        await getSignedMultisigExecuteInput(makeTransferCommand(threshold + 1), owners)
+        await getSignedMultisigExecuteInput(
+          makeTransferCommand(threshold + 1),
+          owners,
+        )
           .then((input) =>
             expect(contract.execute(input))
               .to.emit(contract, 'OwnershipTransferred')
@@ -635,17 +638,19 @@ describe('AxelarGatewayMultisig', () => {
             expect(actual).to.deep.eq(operators.map(get('address')));
           });
 
-        await getSignedMultisigExecuteInput(makeTransferCommand(threshold), operators)
-          .then((input) =>
-            expect(contract.execute(input))
-              .to.emit(contract, 'OwnershipTransferred')
-              .withArgs(
-                operators.map(get('address')),
-                threshold + 1,
-                operators.map(get('address')),
-                threshold,
-              ),
-          )
+        await getSignedMultisigExecuteInput(
+          makeTransferCommand(threshold),
+          operators,
+        ).then((input) =>
+          expect(contract.execute(input))
+            .to.emit(contract, 'OwnershipTransferred')
+            .withArgs(
+              operators.map(get('address')),
+              threshold + 1,
+              operators.map(get('address')),
+              threshold,
+            ),
+        );
       });
 
       it('should allow previous owners to burn tokens', () => {
@@ -765,7 +770,7 @@ describe('AxelarGatewayMultisig', () => {
 
     describe('command transferOperatorship', () => {
       it('should allow owners to transfer operatorship', async () => {
-        const makeTransferCommand = newThreshold =>
+        const makeTransferCommand = (newThreshold) =>
           arrayify(
             defaultAbiCoder.encode(
               ['uint256', 'uint256', 'bytes32[]', 'string[]', 'bytes[]'],
@@ -784,7 +789,10 @@ describe('AxelarGatewayMultisig', () => {
             ),
           );
 
-        await getSignedMultisigExecuteInput(makeTransferCommand(threshold + 1), owners)
+        await getSignedMultisigExecuteInput(
+          makeTransferCommand(threshold + 1),
+          owners,
+        )
           .then((input) =>
             expect(contract.execute(input))
               .to.emit(contract, 'OperatorshipTransferred')
@@ -800,17 +808,19 @@ describe('AxelarGatewayMultisig', () => {
             expect(actual).to.deep.eq(owners.map(get('address')));
           });
 
-        await getSignedMultisigExecuteInput(makeTransferCommand(threshold), owners)
-          .then((input) =>
-            expect(contract.execute(input))
-              .to.emit(contract, 'OperatorshipTransferred')
-              .withArgs(
-                owners.map(get('address')),
-                threshold + 1,
-                owners.map(get('address')),
-                threshold,
-              ),
-          );
+        await getSignedMultisigExecuteInput(
+          makeTransferCommand(threshold),
+          owners,
+        ).then((input) =>
+          expect(contract.execute(input))
+            .to.emit(contract, 'OperatorshipTransferred')
+            .withArgs(
+              owners.map(get('address')),
+              threshold + 1,
+              owners.map(get('address')),
+              threshold,
+            ),
+        );
       });
 
       it('should allow previous operators to burn tokens', () => {

--- a/test/AxelarGatewayMultisig.js
+++ b/test/AxelarGatewayMultisig.js
@@ -683,27 +683,12 @@ describe('AxelarGatewayMultisig', () => {
 
         return getSignedMultisigExecuteInput(data, owners.slice(1, 3))
           .then((input) => contract.execute(input))
-          .then(() => {
-            const data = arrayify(
-              defaultAbiCoder.encode(
-                ['uint256', 'uint256', 'bytes32[]', 'string[]', 'bytes[]'],
-                [
-                  CHAIN_ID,
-                  ROLE_OWNER,
-                  [getRandomID()],
-                  ['transferOwnership'],
-                  [
-                    defaultAbiCoder.encode(
-                      ['address[]', 'uint8'],
-                      [operators.map(get('address')), threshold],
-                    ),
-                  ],
-                ],
-              ),
-            );
-
-            return getSignedMultisigExecuteInput(data, owners);
-          })
+          .then(() =>
+            getSignedMultisigExecuteInput(
+              makeTransferCommand('transferOwnership', operators, threshold),
+              owners,
+            ),
+          )
           .then((input) =>
             expect(contract.execute(input))
               .to.emit(contract, 'OwnershipTransferred')
@@ -834,27 +819,12 @@ describe('AxelarGatewayMultisig', () => {
 
         return getSignedMultisigExecuteInput(data, owners.slice(1, 3))
           .then((input) => contract.execute(input))
-          .then(() => {
-            const data = arrayify(
-              defaultAbiCoder.encode(
-                ['uint256', 'uint256', 'bytes32[]', 'string[]', 'bytes[]'],
-                [
-                  CHAIN_ID,
-                  ROLE_OWNER,
-                  [getRandomID()],
-                  ['transferOperatorship'],
-                  [
-                    defaultAbiCoder.encode(
-                      ['address[]', 'uint8'],
-                      [owners.map(get('address')), threshold],
-                    ),
-                  ],
-                ],
-              ),
-            );
-
-            return getSignedMultisigExecuteInput(data, owners);
-          })
+          .then(() =>
+            getSignedMultisigExecuteInput(
+              makeTransferCommand('transferOperatorship', owners, threshold),
+              owners,
+            ),
+          )
           .then((input) =>
             expect(contract.execute(input))
               .to.emit(contract, 'OperatorshipTransferred')

--- a/test/AxelarGatewayMultisig.js
+++ b/test/AxelarGatewayMultisig.js
@@ -599,26 +599,27 @@ describe('AxelarGatewayMultisig', () => {
     });
 
     describe('command transferOwnership', () => {
-      it('should owners to transfer ownership', () => {
-        const data = arrayify(
-          defaultAbiCoder.encode(
-            ['uint256', 'uint256', 'bytes32[]', 'string[]', 'bytes[]'],
-            [
-              CHAIN_ID,
-              ROLE_OWNER,
-              [getRandomID()],
-              ['transferOwnership'],
+      it('should owners to transfer ownership', async () => {
+        const makeTransferCommand = newThreshold =>
+          arrayify(
+            defaultAbiCoder.encode(
+              ['uint256', 'uint256', 'bytes32[]', 'string[]', 'bytes[]'],
               [
-                defaultAbiCoder.encode(
-                  ['address[]', 'uint8'],
-                  [operators.map(get('address')), threshold],
-                ),
+                CHAIN_ID,
+                ROLE_OWNER,
+                [getRandomID()],
+                ['transferOwnership'],
+                [
+                  defaultAbiCoder.encode(
+                    ['address[]', 'uint8'],
+                    [operators.map(get('address')), newThreshold],
+                  ),
+                ],
               ],
-            ],
-          ),
-        );
+            ),
+          );
 
-        return getSignedMultisigExecuteInput(data, owners)
+        await getSignedMultisigExecuteInput(makeTransferCommand(threshold + 1), owners)
           .then((input) =>
             expect(contract.execute(input))
               .to.emit(contract, 'OwnershipTransferred')
@@ -626,13 +627,25 @@ describe('AxelarGatewayMultisig', () => {
                 owners.map(get('address')),
                 threshold,
                 operators.map(get('address')),
-                threshold,
+                threshold + 1,
               ),
           )
           .then(() => contract.owners())
           .then((actual) => {
             expect(actual).to.deep.eq(operators.map(get('address')));
           });
+
+        await getSignedMultisigExecuteInput(makeTransferCommand(threshold), operators)
+          .then((input) =>
+            expect(contract.execute(input))
+              .to.emit(contract, 'OwnershipTransferred')
+              .withArgs(
+                operators.map(get('address')),
+                threshold + 1,
+                operators.map(get('address')),
+                threshold,
+              ),
+          )
       });
 
       it('should allow previous owners to burn tokens', () => {
@@ -751,26 +764,27 @@ describe('AxelarGatewayMultisig', () => {
     });
 
     describe('command transferOperatorship', () => {
-      it('should owners to transfer operatorship', () => {
-        const data = arrayify(
-          defaultAbiCoder.encode(
-            ['uint256', 'uint256', 'bytes32[]', 'string[]', 'bytes[]'],
-            [
-              CHAIN_ID,
-              ROLE_OWNER,
-              [getRandomID()],
-              ['transferOperatorship'],
+      it('should allow owners to transfer operatorship', async () => {
+        const makeTransferCommand = newThreshold =>
+          arrayify(
+            defaultAbiCoder.encode(
+              ['uint256', 'uint256', 'bytes32[]', 'string[]', 'bytes[]'],
               [
-                defaultAbiCoder.encode(
-                  ['address[]', 'uint8'],
-                  [owners.map(get('address')), threshold],
-                ),
+                CHAIN_ID,
+                ROLE_OWNER,
+                [getRandomID()],
+                ['transferOperatorship'],
+                [
+                  defaultAbiCoder.encode(
+                    ['address[]', 'uint8'],
+                    [owners.map(get('address')), newThreshold],
+                  ),
+                ],
               ],
-            ],
-          ),
-        );
+            ),
+          );
 
-        return getSignedMultisigExecuteInput(data, owners)
+        await getSignedMultisigExecuteInput(makeTransferCommand(threshold + 1), owners)
           .then((input) =>
             expect(contract.execute(input))
               .to.emit(contract, 'OperatorshipTransferred')
@@ -778,13 +792,25 @@ describe('AxelarGatewayMultisig', () => {
                 operators.map(get('address')),
                 threshold,
                 owners.map(get('address')),
-                threshold,
+                threshold + 1,
               ),
           )
           .then(() => contract.operators())
           .then((actual) => {
             expect(actual).to.deep.eq(owners.map(get('address')));
           });
+
+        await getSignedMultisigExecuteInput(makeTransferCommand(threshold), owners)
+          .then((input) =>
+            expect(contract.execute(input))
+              .to.emit(contract, 'OperatorshipTransferred')
+              .withArgs(
+                owners.map(get('address')),
+                threshold + 1,
+                owners.map(get('address')),
+                threshold,
+              ),
+          );
       });
 
       it('should allow previous operators to burn tokens', () => {

--- a/test/AxelarGatewayMultisig.js
+++ b/test/AxelarGatewayMultisig.js
@@ -39,6 +39,25 @@ describe('AxelarGatewayMultisig', () => {
   let contract;
   let tokenDeployer;
 
+  const makeTransferCommand = (commandName, newSet, newThreshold) =>
+    arrayify(
+      defaultAbiCoder.encode(
+        ['uint256', 'uint256', 'bytes32[]', 'string[]', 'bytes[]'],
+        [
+          CHAIN_ID,
+          ROLE_OWNER,
+          [getRandomID()],
+          [commandName],
+          [
+            defaultAbiCoder.encode(
+              ['address[]', 'uint8'],
+              [newSet.map(get('address')), newThreshold],
+            ),
+          ],
+        ],
+      ),
+    );
+
   beforeEach(async () => {
     const params = arrayify(
       defaultAbiCoder.encode(
@@ -600,27 +619,8 @@ describe('AxelarGatewayMultisig', () => {
 
     describe('command transferOwnership', () => {
       it('should owners to transfer ownership', async () => {
-        const makeTransferCommand = (newThreshold) =>
-          arrayify(
-            defaultAbiCoder.encode(
-              ['uint256', 'uint256', 'bytes32[]', 'string[]', 'bytes[]'],
-              [
-                CHAIN_ID,
-                ROLE_OWNER,
-                [getRandomID()],
-                ['transferOwnership'],
-                [
-                  defaultAbiCoder.encode(
-                    ['address[]', 'uint8'],
-                    [operators.map(get('address')), newThreshold],
-                  ),
-                ],
-              ],
-            ),
-          );
-
         await getSignedMultisigExecuteInput(
-          makeTransferCommand(threshold + 1),
+          makeTransferCommand('transferOwnership', operators, threshold + 1),
           owners,
         )
           .then((input) =>
@@ -639,7 +639,7 @@ describe('AxelarGatewayMultisig', () => {
           });
 
         await getSignedMultisigExecuteInput(
-          makeTransferCommand(threshold),
+          makeTransferCommand('transferOwnership', operators, threshold),
           operators,
         ).then((input) =>
           expect(contract.execute(input))
@@ -770,27 +770,8 @@ describe('AxelarGatewayMultisig', () => {
 
     describe('command transferOperatorship', () => {
       it('should allow owners to transfer operatorship', async () => {
-        const makeTransferCommand = (newThreshold) =>
-          arrayify(
-            defaultAbiCoder.encode(
-              ['uint256', 'uint256', 'bytes32[]', 'string[]', 'bytes[]'],
-              [
-                CHAIN_ID,
-                ROLE_OWNER,
-                [getRandomID()],
-                ['transferOperatorship'],
-                [
-                  defaultAbiCoder.encode(
-                    ['address[]', 'uint8'],
-                    [owners.map(get('address')), newThreshold],
-                  ),
-                ],
-              ],
-            ),
-          );
-
         await getSignedMultisigExecuteInput(
-          makeTransferCommand(threshold + 1),
+          makeTransferCommand('transferOperatorship', owners, threshold + 1),
           owners,
         )
           .then((input) =>
@@ -809,7 +790,7 @@ describe('AxelarGatewayMultisig', () => {
           });
 
         await getSignedMultisigExecuteInput(
-          makeTransferCommand(threshold),
+          makeTransferCommand('transferOperatorship', owners, threshold),
           owners,
         ).then((input) =>
           expect(contract.execute(input))


### PR DESCRIPTION
* [x] `OperatorshipTransferred` event: using operatorEpoch for getting old threshold  value
* [x] Tests: coverage for `OwnershipTransferred` and `OperatorshipTransferred` events