### PR TITLE
fix(Gateway): using `abi.encode` for CallApprovedKey

### DIFF
--- a/src/AxelarGateway.sol
+++ b/src/AxelarGateway.sol
@@ -476,7 +476,7 @@ abstract contract AxelarGateway is IAxelarGateway, AdminMultisigBase {
     ) internal pure returns (bytes32) {
         return
             keccak256(
-                abi.encodePacked(
+                abi.encode(
                     PREFIX_CONTRACT_CALL_APPROVED,
                     commandId,
                     sourceChain,
@@ -498,7 +498,7 @@ abstract contract AxelarGateway is IAxelarGateway, AdminMultisigBase {
     ) internal pure returns (bytes32) {
         return
             keccak256(
-                abi.encodePacked(
+                abi.encode(
                     PREFIX_CONTRACT_CALL_APPROVED_WITH_MINT,
                     commandId,
                     sourceChain,


### PR DESCRIPTION
* [x] `_getIsContractCallApprovedKey`, `_getIsContractCallApprovedWithMintKey`: using `abi.encode` instead of `abi.encodePacked` as we have variable length strings among hashing params