### PR TITLE
Gateway: token deployer storage + upgrade

### DIFF
--- a/src/AxelarGatewayMultisig.sol
+++ b/src/AxelarGatewayMultisig.sol
@@ -36,8 +36,6 @@ contract AxelarGatewayMultisig is IAxelarGatewayMultisig, AxelarGateway {
     bytes32 internal constant PREFIX_OPERATOR_THRESHOLD = keccak256('operator-threshold');
     bytes32 internal constant PREFIX_IS_OPERATOR = keccak256('is-operator');
 
-    constructor(address tokenDeployer) AxelarGateway(tokenDeployer) {}
-
     function _isSortedAscAndContainsNoDuplicate(address[] memory accounts) internal pure returns (bool) {
         for (uint256 i; i < accounts.length - 1; ++i) {
             if (accounts[i] >= accounts[i + 1]) {

--- a/src/AxelarGatewayProxy.sol
+++ b/src/AxelarGatewayProxy.sol
@@ -12,9 +12,17 @@ contract AxelarGatewayProxy is EternalStorage {
     /// @dev Storage slot with the address of the current factory. `keccak256('eip1967.proxy.implementation') - 1`.
     bytes32 internal constant KEY_IMPLEMENTATION =
         bytes32(0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc);
+    /// @dev Storage slot with the address of the current token deployer. `bytes32(uint256(keccak256('eip1967.proxy.token.deployer')) - 1)`
+    bytes32 internal constant KEY_TOKEN_DEPLOYER_IMPLEMENTATION =
+        bytes32(0x8aa47aa9d723e8543a50fff50c962bb34dd4a647318775b399bf923741a6636d);
 
-    constructor(address gatewayImplementation, bytes memory params) {
+    constructor(
+        address gatewayImplementation,
+        address tokenDeployerImplementation,
+        bytes memory params
+    ) {
         _setAddress(KEY_IMPLEMENTATION, gatewayImplementation);
+        _setAddress(KEY_TOKEN_DEPLOYER_IMPLEMENTATION, tokenDeployerImplementation);
 
         (bool success, ) = gatewayImplementation.delegatecall(
             abi.encodeWithSelector(IAxelarGateway.setup.selector, params)

--- a/src/AxelarGatewaySinglesig.sol
+++ b/src/AxelarGatewaySinglesig.sol
@@ -21,8 +21,6 @@ contract AxelarGatewaySinglesig is IAxelarGatewaySinglesig, AxelarGateway {
 
     bytes32 internal constant PREFIX_OPERATOR = keccak256('operator');
 
-    constructor(address tokenDeployer) AxelarGateway(tokenDeployer) {}
-
     /********************\
     |* Pure Key Getters *|
     \********************/

--- a/src/interfaces/IAxelarGateway.sol
+++ b/src/interfaces/IAxelarGateway.sol
@@ -73,6 +73,8 @@ interface IAxelarGateway {
 
     event Upgraded(address indexed implementation);
 
+    event TokenDeployerUpgraded(address indexed implementation);
+
     /******************\
     |* Public Methods *|
     \******************/
@@ -169,6 +171,8 @@ interface IAxelarGateway {
         bytes32 newImplementationCodeHash,
         bytes calldata setupParams
     ) external;
+
+    function upgradeTokenDeployer(address newImplementation, bytes32 newImplementationCodeHash) external;
 
     /**********************\
     |* External Functions *|

--- a/test/AxelarGatewayMultisig.js
+++ b/test/AxelarGatewayMultisig.js
@@ -73,11 +73,10 @@ describe('AxelarGatewayMultisig', () => {
       ),
     );
     tokenDeployer = await deployContract(wallets[0], TokenDeployer);
-    const gateway = await deployContract(wallets[0], AxelarGatewayMultisig, [
-      tokenDeployer.address,
-    ]);
+    const gateway = await deployContract(wallets[0], AxelarGatewayMultisig);
     const proxy = await deployContract(wallets[0], AxelarGatewayProxy, [
       gateway.address,
+      tokenDeployer.address,
       params,
     ]);
     contract = new Contract(
@@ -113,7 +112,6 @@ describe('AxelarGatewayMultisig', () => {
       const newImplementation = await deployContract(
         wallets[0],
         AxelarGatewayMultisig,
-        [tokenDeployer.address],
       );
       const newImplementationCode = await newImplementation.provider.getCode(
         newImplementation.address,

--- a/test/AxelarGatewaySinglesig.js
+++ b/test/AxelarGatewaySinglesig.js
@@ -109,11 +109,10 @@ describe('AxelarGatewaySingleSig', () => {
       ),
     );
     tokenDeployer = await deployContract(ownerWallet, TokenDeployer);
-    const gateway = await deployContract(ownerWallet, AxelarGatewaySinglesig, [
-      tokenDeployer.address,
-    ]);
+    const gateway = await deployContract(ownerWallet, AxelarGatewaySinglesig);
     const proxy = await deployContract(ownerWallet, AxelarGatewayProxy, [
       gateway.address,
+      tokenDeployer.address,
       params,
     ]);
     contract = new Contract(
@@ -345,7 +344,6 @@ describe('AxelarGatewaySingleSig', () => {
       const newImplementation = await deployContract(
         ownerWallet,
         AxelarGatewaySinglesig,
-        [tokenDeployer.address],
       );
       const wrongImplementationCodeHash = keccak256(
         `0x${AxelarGatewaySinglesig.bytecode}`,
@@ -399,7 +397,6 @@ describe('AxelarGatewaySingleSig', () => {
       const newImplementation = await deployContract(
         ownerWallet,
         AxelarGatewaySinglesig,
-        [tokenDeployer.address],
       );
       const newImplementationCode = await newImplementation.provider.getCode(
         newImplementation.address,


### PR DESCRIPTION
* [x] Removed `immutable TOKEN_DEPLOYER_IMPLEMENTATION`
* [x] Added `KEY_TOKEN_DEPLOYER_IMPLEMENTATION` storage slot
* [x] Changed proxy constructor and added `upgradeTokenDeployer` method
* [ ] Problem: `AxelarGatewayMultisig` contract code size exceeds 24576 bytes
