### PR TITLE
fix(Gateway): addressing the important CodeArena reports

### DIFF
--- a/contracts/AxelarGateway.sol
+++ b/contracts/AxelarGateway.sol
@@ -453,7 +453,10 @@ contract AxelarGateway is IAxelarGateway, AdminMultisigBase {
     function _callERC20Token(address tokenAddress, bytes memory callData) internal returns (bool) {
         // solhint-disable-next-line avoid-low-level-calls
         (bool success, bytes memory returnData) = tokenAddress.call(callData);
-        return success && tokenAddress.code.length != 0 && (returnData.length == 0 || abi.decode(returnData, (bool)));
+        if (tokenAddress.code.length == 0) return false
+
+        (bool success, bytes memory returnData) = tokenAddress.call(callData);
+        return success && (returnData.length == 0 || abi.decode(returnData, (bool)));
     }
 
     function _mintToken(

--- a/contracts/AxelarGateway.sol
+++ b/contracts/AxelarGateway.sol
@@ -453,10 +453,7 @@ contract AxelarGateway is IAxelarGateway, AdminMultisigBase {
     function _callERC20Token(address tokenAddress, bytes memory callData) internal returns (bool) {
         // solhint-disable-next-line avoid-low-level-calls
         (bool success, bytes memory returnData) = tokenAddress.call(callData);
-        if (tokenAddress.code.length == 0) return false
-
-        (bool success, bytes memory returnData) = tokenAddress.call(callData);
-        return success && (returnData.length == 0 || abi.decode(returnData, (bool)));
+        return success && tokenAddress.code.length != 0 && (returnData.length == 0 || abi.decode(returnData, (bool)));
     }
 
     function _mintToken(

--- a/contracts/AxelarGateway.sol
+++ b/contracts/AxelarGateway.sol
@@ -23,7 +23,7 @@ contract AxelarGateway is IAxelarGateway, AdminMultisigBase {
     // bytes32 internal constant KEY_ALL_TOKENS_FROZEN = keccak256('all-tokens-frozen');
     // bytes32 internal constant PREFIX_TOKEN_FROZEN = keccak256('token-frozen');
 
-    /// @dev Storage slot with the address of the current factory. `keccak256('eip1967.proxy.implementation') - 1`.
+    /// @dev Storage slot with the address of the current implementation. `keccak256('eip1967.proxy.implementation') - 1`.
     bytes32 internal constant KEY_IMPLEMENTATION = bytes32(0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc);
 
     // AUDIT: slot names should be prefixed with some standard string
@@ -42,8 +42,10 @@ contract AxelarGateway is IAxelarGateway, AdminMultisigBase {
     bytes32 internal constant SELECTOR_APPROVE_CONTRACT_CALL_WITH_MINT = keccak256('approveContractCallWithMint');
     bytes32 internal constant SELECTOR_TRANSFER_OPERATORSHIP = keccak256('transferOperatorship');
 
-    address internal immutable AUTH_MODULE;
-    address internal immutable TOKEN_DEPLOYER_IMPLEMENTATION;
+    // solhint-disable-next-line var-name-mixedcase
+    address public immutable AUTH_MODULE;
+    // solhint-disable-next-line var-name-mixedcase
+    address public immutable TOKEN_DEPLOYER_IMPLEMENTATION;
 
     constructor(address authModule, address tokenDeployerImplementation) {
         if (authModule.code.length == 0) revert InvalidAuthModule();
@@ -139,7 +141,7 @@ contract AxelarGateway is IAxelarGateway, AdminMultisigBase {
         bytes32 key = _getIsContractCallApprovedWithMintKey(commandId, sourceChain, sourceAddress, msg.sender, payloadHash, symbol, amount);
         valid = getBool(key);
         if (valid) {
-            // Prevent re-entrancy
+            // Prevent re-entrance
             _setBool(key, false);
             _mintToken(symbol, msg.sender, amount);
         }
@@ -154,14 +156,12 @@ contract AxelarGateway is IAxelarGateway, AdminMultisigBase {
     }
 
     function tokenDailyMintAmount(string memory symbol) public view override returns (uint256) {
+        // solhint-disable-next-line not-rely-on-time
         return getUint(_getTokenDailyMintAmountKey(symbol, block.timestamp / 1 days));
     }
 
-    /*
-     * @dev This function is kept around to keep things working for internal
-     * tokens that were deployed before the token freeze functionality was
-     * removed
-     */
+    /// @dev This function is kept around to keep things working for internal
+    /// tokens that were deployed before the token freeze functionality was removed
     function allTokensFrozen() external pure override returns (bool) {
         return false;
     }
@@ -174,11 +174,8 @@ contract AxelarGateway is IAxelarGateway, AdminMultisigBase {
         return getAddress(_getTokenAddressKey(symbol));
     }
 
-    /*
-     * @dev This function is kept around to keep things working for internal
-     * tokens that were deployed before the token freeze functionality was
-     * removed
-     */
+    /// @dev This function is kept around to keep things working for internal
+    /// tokens that were deployed before the token freeze functionality was removed
     function tokenFrozen(string memory) external pure override returns (bool) {
         return false;
     }
@@ -236,6 +233,7 @@ contract AxelarGateway is IAxelarGateway, AdminMultisigBase {
         // AUDIT: If `newImplementation.setup` performs `selfdestruct`, it will result in the loss of _this_ implementation (thereby losing the gateway)
         //        if `upgrade` is entered within the context of _this_ implementation itself.
         if (setupParams.length != 0) {
+            // solhint-disable-next-line avoid-low-level-calls
             (bool success, ) = newImplementation.delegatecall(abi.encodeWithSelector(IAxelarGateway.setup.selector, setupParams));
 
             if (!success) revert SetupFailed();
@@ -248,6 +246,7 @@ contract AxelarGateway is IAxelarGateway, AdminMultisigBase {
     |* External Functions *|
     \**********************/
 
+    /// @dev Not publicly accessible as overshadowed in the proxy
     function setup(bytes calldata params) external override {
         // Prevent setup from being called on a non-proxy (the implementation).
         if (implementation() == address(0)) revert NotProxy();
@@ -262,7 +261,7 @@ contract AxelarGateway is IAxelarGateway, AdminMultisigBase {
         _setAdminEpoch(newAdminEpoch);
         _setAdmins(newAdminEpoch, adminAddresses, newAdminThreshold);
 
-        if (newOperatorsData.length > 0) {
+        if (newOperatorsData.length != 0) {
             IAxelarAuth(AUTH_MODULE).transferOperatorship(newOperatorsData);
 
             emit OperatorshipTransferred(newOperatorsData);
@@ -282,16 +281,7 @@ contract AxelarGateway is IAxelarGateway, AdminMultisigBase {
         string[] memory commands;
         bytes[] memory params;
 
-        try AxelarGateway(this)._unpackLegacyCommands(data) returns (
-            uint256 chainId_,
-            bytes32[] memory commandIds_,
-            string[] memory commands_,
-            bytes[] memory params_
-        ) {
-            (chainId, commandIds, commands, params) = (chainId_, commandIds_, commands_, params_);
-        } catch {
-            (chainId, commandIds, commands, params) = abi.decode(data, (uint256, bytes32[], string[], bytes[]));
-        }
+        (chainId, commandIds, commands, params) = abi.decode(data, (uint256, bytes32[], string[], bytes[]));
 
         if (chainId != block.chainid) revert InvalidChainId();
 
@@ -327,10 +317,15 @@ contract AxelarGateway is IAxelarGateway, AdminMultisigBase {
 
             // Prevent a re-entrancy from executing this command before it can be marked as successful.
             _setCommandExecuted(commandId, true);
+            // solhint-disable-next-line avoid-low-level-calls
             (bool success, ) = address(this).call(abi.encodeWithSelector(commandSelector, params[i], commandId));
 
-            if (success) emit Executed(commandId);
-            else _setCommandExecuted(commandId, false);
+            if (success) {
+                emit Executed(commandId);
+
+                // Not current operators anymore
+                if (commandSelector == AxelarGateway.transferOperatorship.selector) currentOperators = false;
+            } else _setCommandExecuted(commandId, false);
         }
     }
 
@@ -351,6 +346,7 @@ contract AxelarGateway is IAxelarGateway, AdminMultisigBase {
             // If token address is no specified, it indicates a request to deploy one.
             bytes32 salt = keccak256(abi.encodePacked(symbol));
 
+            // solhint-disable-next-line avoid-low-level-calls
             (bool success, bytes memory data) = TOKEN_DEPLOYER_IMPLEMENTATION.delegatecall(
                 abi.encodeWithSelector(ITokenDeployer.deployToken.selector, name, symbol, decimals, cap, salt)
             );
@@ -454,22 +450,10 @@ contract AxelarGateway is IAxelarGateway, AdminMultisigBase {
     |* Internal Methods *|
     \********************/
 
-    function _unpackLegacyCommands(bytes memory executeData)
-        external
-        pure
-        returns (
-            uint256 chainId,
-            bytes32[] memory commandIds,
-            string[] memory commands,
-            bytes[] memory params
-        )
-    {
-        (chainId, , commandIds, commands, params) = abi.decode(executeData, (uint256, uint256, bytes32[], string[], bytes[]));
-    }
-
     function _callERC20Token(address tokenAddress, bytes memory callData) internal returns (bool) {
+        // solhint-disable-next-line avoid-low-level-calls
         (bool success, bytes memory returnData) = tokenAddress.call(callData);
-        return success && (returnData.length == uint256(0) || abi.decode(returnData, (bool)));
+        return success && tokenAddress.code.length != 0 && (returnData.length == 0 || abi.decode(returnData, (bool)));
     }
 
     function _mintToken(
@@ -551,7 +535,8 @@ contract AxelarGateway is IAxelarGateway, AdminMultisigBase {
     }
 
     function _getTokenDailyMintAmountKey(string memory symbol, uint256 day) internal pure returns (bytes32) {
-        return keccak256(abi.encodePacked(PREFIX_TOKEN_DAILY_MINT_AMOUNT, symbol, day));
+        // abi.encode to securely hash dynamic-length symbol data followed by day
+        return keccak256(abi.encode(PREFIX_TOKEN_DAILY_MINT_AMOUNT, symbol, day));
     }
 
     function _getTokenTypeKey(string memory symbol) internal pure returns (bytes32) {
@@ -622,6 +607,7 @@ contract AxelarGateway is IAxelarGateway, AdminMultisigBase {
         uint256 limit = tokenDailyMintLimit(symbol);
         if (limit > 0 && amount > limit) revert ExceedDailyMintLimit(symbol);
 
+        // solhint-disable-next-line not-rely-on-time
         _setUint(_getTokenDailyMintAmountKey(symbol, block.timestamp / 1 days), amount);
     }
 

--- a/contracts/AxelarGatewayProxy.sol
+++ b/contracts/AxelarGatewayProxy.sol
@@ -9,6 +9,7 @@ import { EternalStorage } from './EternalStorage.sol';
 contract AxelarGatewayProxy is EternalStorage {
     error InvalidImplementation();
     error SetupFailed();
+    error NativeCurrencyNotAccepted();
 
     /// @dev Storage slot with the address of the current factory. `keccak256('eip1967.proxy.implementation') - 1`.
     bytes32 internal constant KEY_IMPLEMENTATION = bytes32(0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc);
@@ -18,16 +19,20 @@ contract AxelarGatewayProxy is EternalStorage {
 
         if (gatewayImplementation.code.length == 0) revert InvalidImplementation();
 
+        // solhint-disable-next-line avoid-low-level-calls
         (bool success, ) = gatewayImplementation.delegatecall(abi.encodeWithSelector(IAxelarGateway.setup.selector, params));
 
         if (!success) revert SetupFailed();
     }
 
+    // solhint-disable-next-line no-empty-blocks
     function setup(bytes calldata params) external {}
 
+    // solhint-disable-next-line no-complex-fallback
     fallback() external payable {
         address implementation = getAddress(KEY_IMPLEMENTATION);
 
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             calldatacopy(0, 0, calldatasize())
 
@@ -46,6 +51,6 @@ contract AxelarGatewayProxy is EternalStorage {
     }
 
     receive() external payable {
-        revert('NO_ETHER');
+        revert NativeCurrencyNotAccepted();
     }
 }

--- a/contracts/interfaces/IAxelarGateway.sol
+++ b/contracts/interfaces/IAxelarGateway.sol
@@ -144,6 +144,12 @@ interface IAxelarGateway {
     |* Getters *|
     \***********/
 
+    // solhint-disable-next-line func-name-mixedcase
+    function AUTH_MODULE() external view returns (address);
+
+    // solhint-disable-next-line func-name-mixedcase
+    function TOKEN_DEPLOYER_IMPLEMENTATION() external view returns (address);
+
     function tokenDailyMintLimit(string memory symbol) external view returns (uint256);
 
     function tokenDailyMintAmount(string memory symbol) external view returns (uint256);

--- a/contracts/interfaces/IAxelarGateway.sol
+++ b/contracts/interfaces/IAxelarGateway.sol
@@ -144,11 +144,9 @@ interface IAxelarGateway {
     |* Getters *|
     \***********/
 
-    // solhint-disable-next-line func-name-mixedcase
-    function AUTH_MODULE() external view returns (address);
+    function authModule() external view returns (address);
 
-    // solhint-disable-next-line func-name-mixedcase
-    function TOKEN_DEPLOYER_IMPLEMENTATION() external view returns (address);
+    function tokenDeployer() external view returns (address);
 
     function tokenDailyMintLimit(string memory symbol) external view returns (uint256);
 

--- a/test/AxelarDepositService.js
+++ b/test/AxelarDepositService.js
@@ -11,7 +11,6 @@ const { expect } = chai;
 const { get } = require('lodash/fp');
 
 const CHAIN_ID = 1;
-const ROLE_OWNER = 1;
 
 const Auth = require('../artifacts/contracts/auth/AxelarAuthWeighted.sol/AxelarAuthWeighted.json');
 const TokenDeployer = require('../artifacts/contracts/TokenDeployer.sol/TokenDeployer.json');
@@ -68,10 +67,9 @@ describe('AxelarDepositService', () => {
             await getSignedWeightedExecuteInput(
                 arrayify(
                     defaultAbiCoder.encode(
-                        ['uint256', 'uint256', 'bytes32[]', 'string[]', 'bytes[]'],
+                        ['uint256', 'bytes32[]', 'string[]', 'bytes[]'],
                         [
                             CHAIN_ID,
-                            ROLE_OWNER,
                             [getRandomID()],
                             ['deployToken'],
                             [

--- a/test/gmp/GeneralMessagePassing.js
+++ b/test/gmp/GeneralMessagePassing.js
@@ -13,7 +13,6 @@ const { deployUpgradable } = require('../../scripts/upgradable');
 
 const CHAIN_ID = 1;
 const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000';
-const ROLE_OWNER = 1;
 
 const Auth = require('../../artifacts/contracts/auth/AxelarAuthWeighted.sol/AxelarAuthWeighted.json');
 const TokenDeployer = require('../../artifacts/contracts/TokenDeployer.sol/TokenDeployer.json');
@@ -58,10 +57,9 @@ describe('GeneralMessagePassing', () => {
     const getMintData = (symbol, address, amount) =>
         arrayify(
             defaultAbiCoder.encode(
-                ['uint256', 'uint256', 'bytes32[]', 'string[]', 'bytes[]'],
+                ['uint256', 'bytes32[]', 'string[]', 'bytes[]'],
                 [
                     CHAIN_ID,
-                    ROLE_OWNER,
                     [getRandomID()],
                     ['mintToken'],
                     [defaultAbiCoder.encode(['string', 'address', 'uint256'], [symbol, address, amount])],
@@ -85,10 +83,9 @@ describe('GeneralMessagePassing', () => {
         const getTokenDeployData = (withAddress) =>
             arrayify(
                 defaultAbiCoder.encode(
-                    ['uint256', 'uint256', 'bytes32[]', 'string[]', 'bytes[]'],
+                    ['uint256', 'bytes32[]', 'string[]', 'bytes[]'],
                     [
                         CHAIN_ID,
-                        ROLE_OWNER,
                         [getRandomID(), getRandomID()],
                         ['deployToken', 'deployToken'],
                         [
@@ -194,10 +191,9 @@ describe('GeneralMessagePassing', () => {
 
             const approveWithMintData = arrayify(
                 defaultAbiCoder.encode(
-                    ['uint256', 'uint256', 'bytes32[]', 'string[]', 'bytes[]'],
+                    ['uint256', 'bytes32[]', 'string[]', 'bytes[]'],
                     [
                         CHAIN_ID,
-                        ROLE_OWNER,
                         [approveCommandId],
                         ['approveContractCallWithMint'],
                         [
@@ -317,10 +313,9 @@ describe('GeneralMessagePassing', () => {
 
             const approveWithMintData = arrayify(
                 defaultAbiCoder.encode(
-                    ['uint256', 'uint256', 'bytes32[]', 'string[]', 'bytes[]'],
+                    ['uint256', 'bytes32[]', 'string[]', 'bytes[]'],
                     [
                         CHAIN_ID,
-                        ROLE_OWNER,
                         [approveCommandId],
                         ['approveContractCallWithMint'],
                         [


### PR DESCRIPTION
* [x] Setting `currentOperators` to false when transfer is command successfully executed
* [x] Removed support for legacy batch with signer role. Fixed tests using legacy batches
* [x] Fix the abi encoding of the key for `dailyMintAmount`
* [x] Additional security unit tests for the gateway
* [x] Made auth module/token deployer public and queryable.
* [x] Code length check for `_callERC20Token`
* [x] Suppressed lint warnings with comments
 