### PR TITLE
fix(AuthWeighted): improving error messages

### DIFF
--- a/contracts/auth/AxelarAuthWeighted.sol
+++ b/contracts/auth/AxelarAuthWeighted.sol
@@ -23,7 +23,9 @@ contract AxelarAuthWeighted is Ownable, IAxelarAuthWeighted {
     |* External Functionality *|
     \**************************/
 
-    function validateProof(bytes32 messageHash, bytes calldata proof) external view returns (bool currentOperators) {
+    /// @dev This function takes messageHash and proof data and reverts if proof is invalid
+    /// @return True if provided operators are the current ones
+    function validateProof(bytes32 messageHash, bytes calldata proof) external view returns (bool) {
         (address[] memory operators, uint256[] memory weights, uint256 threshold, bytes[] memory signatures) = abi.decode(
             proof,
             (address[], uint256[], uint256, bytes[])
@@ -37,7 +39,7 @@ contract AxelarAuthWeighted is Ownable, IAxelarAuthWeighted {
 
         _validateSignatures(messageHash, operators, weights, threshold, signatures);
 
-        currentOperators = operatorsEpoch == epoch;
+        return operatorsEpoch == epoch;
     }
 
     /***********************\
@@ -73,7 +75,7 @@ contract AxelarAuthWeighted is Ownable, IAxelarAuthWeighted {
 
         bytes32 newOperatorsHash = keccak256(params);
 
-        if (epochForHash[newOperatorsHash] > 0) revert SameOperators();
+        if (epochForHash[newOperatorsHash] > 0) revert DuplicateOperators();
 
         uint256 epoch = currentEpoch + 1;
         currentEpoch = epoch;
@@ -109,7 +111,7 @@ contract AxelarAuthWeighted is Ownable, IAxelarAuthWeighted {
             ++operatorIndex;
         }
         // if weight sum below threshold
-        revert MalformedSigners();
+        revert LowSignaturesWeight();
     }
 
     function _isSortedAscAndContainsNoDuplicate(address[] memory accounts) internal pure returns (bool) {

--- a/contracts/interfaces/IAxelarAuthWeighted.sol
+++ b/contracts/interfaces/IAxelarAuthWeighted.sol
@@ -7,8 +7,9 @@ import { IAxelarAuth } from './IAxelarAuth.sol';
 interface IAxelarAuthWeighted is IAxelarAuth {
     error InvalidOperators();
     error InvalidThreshold();
-    error SameOperators();
+    error DuplicateOperators();
     error MalformedSigners();
+    error LowSignaturesWeight();
     error InvalidWeights();
 
     event OperatorshipTransferred(address[] newOperators, uint256[] newWeights, uint256 newThreshold);

--- a/test/auth/AxelarAuthWeighted.js
+++ b/test/auth/AxelarAuthWeighted.js
@@ -98,7 +98,7 @@ describe('AxelarAuthWeighted', () => {
                         operators.slice(0, threshold - 1),
                     ),
                 ),
-            ).to.be.revertedWith('MalformedSigners()');
+            ).to.be.revertedWith('LowSignaturesWeight()');
         });
 
         it('reject the proof if signatures are invalid', async () => {
@@ -285,7 +285,7 @@ describe('AxelarAuthWeighted', () => {
                         threshold,
                     ),
                 ),
-            ).to.be.revertedWith('SameOperators()');
+            ).to.be.revertedWith('DuplicateOperators()');
         });
 
         it('should not allow transferring operatorship with invalid threshold', async () => {


### PR DESCRIPTION
* [x] Better error messages: `LowSignaturesWeight()`, `DuplicateOperators()`
