### PR TITLE
chore: support node version 16.x and 18.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "solidity-coverage": "^0.7.21"
   },
   "engines": {
-    "node": ">=16 <17"
+    "node": "^16.0.0 || ^18.0.0"
   }
 }


### PR DESCRIPTION
This PR allows node versions `16.x` and `18.x` to install this package since hardhat supports every currently maintained LTS node.js version as mentioned [here](https://hardhat.org/hardhat-runner/docs/reference/stability-guarantees#node.js-versions-support). The version is copied from the hardhat package [here](https://github.com/NomicFoundation/hardhat/blob/97d71e15e7b407ca1336b4c265aa2e9db5a98b53/packages/hardhat-core/package.json#L26), but I exclude version `14.x` because it won't be maintained anymore in the next few months.