### PR TITLE
test(ServiceProxy): should preserve Proxy bytecode

### DIFF
--- a/test-evm-versions.bash
+++ b/test-evm-versions.bash
@@ -9,11 +9,11 @@ declare -a versions=(
 for version in "${versions[@]}"
 do
   echo "Building and testing for EVM version: $version"
-  EVM_VERSION=$version hardhat compile || {
+  EVM_VERSION=$version npm run build || {
     echo "Error: build failed for EVM version: $version"
     exit 1
   }
-  hardhat test --no-compile || {
+  EVM_VERSION=$version npm t -- --no-compile || {
    echo "Error: tests failed for EVM version: $version"
    exit 1
   }

--- a/test/AxelarDepositService.js
+++ b/test/AxelarDepositService.js
@@ -355,6 +355,12 @@ describe('AxelarDepositService', () => {
             ).to.changeEtherBalance(userWallet, amount);
         });
 
+        it('should have the same receiver bytecode', async () => {
+            await expect(keccak256(DepositReceiver.bytecode)).to.be.equal(
+              '0xc0fd88839756e97f51ab0395ce8e6164a5f924bd73a3342204340a14ad306fe1',
+            );
+        });
+
         it('should refund have the same proxy bytecode', async () => {
             const proxyBytecode = DepositServiceProxy.bytecode;
             const proxyBytecodeHash = keccak256(proxyBytecode);

--- a/test/AxelarDepositService.js
+++ b/test/AxelarDepositService.js
@@ -354,5 +354,12 @@ describe('AxelarDepositService', () => {
                 await depositService.connect(ownerWallet).refundLockedAsset(recipient, ADDRESS_ZERO, amount),
             ).to.changeEtherBalance(userWallet, amount);
         });
+
+        it('should refund have the same proxy bytecode', async () => {
+            const proxyBytecode = DepositServiceProxy.bytecode;
+            const proxyBytecodeHash = keccak256(proxyBytecode);
+
+            expect(proxyBytecodeHash).to.be.equal('0xdec34d6bd2779b58de66dc79f2d80353e8cebb178d9afac4225bc3f652360aaa');
+        });
     });
 });

--- a/test/AxelarDepositService.js
+++ b/test/AxelarDepositService.js
@@ -1,14 +1,17 @@
 'use strict';
 
 const chai = require('chai');
+const { config, ethers} = require('hardhat');
 const {
     Contract,
     utils: { defaultAbiCoder, arrayify, solidityPack, formatBytes32String, keccak256, getCreate2Address },
-} = require('ethers');
+} = ethers;
 const { deployContract, MockProvider, solidity } = require('ethereum-waffle');
 chai.use(solidity);
 const { expect } = chai;
 const { get } = require('lodash/fp');
+
+const EVM_VERSION = config.solidity.compilers[0].settings.evmVersion;
 
 const CHAIN_ID = 1;
 const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000';
@@ -356,16 +359,28 @@ describe('AxelarDepositService', () => {
         });
 
         it('should have the same receiver bytecode', async () => {
+            const expected = {
+                istanbul: '0xc0fd88839756e97f51ab0395ce8e6164a5f924bd73a3342204340a14ad306fe1',
+                berlin: '0xc0fd88839756e97f51ab0395ce8e6164a5f924bd73a3342204340a14ad306fe1',
+                london: '0xc0fd88839756e97f51ab0395ce8e6164a5f924bd73a3342204340a14ad306fe1',
+            }[EVM_VERSION]
+
             await expect(keccak256(DepositReceiver.bytecode)).to.be.equal(
-              '0xc0fd88839756e97f51ab0395ce8e6164a5f924bd73a3342204340a14ad306fe1',
+              expected,
             );
         });
 
-        it('should refund have the same proxy bytecode', async () => {
+        it('should have the same proxy bytecode', async () => {
             const proxyBytecode = DepositServiceProxy.bytecode;
             const proxyBytecodeHash = keccak256(proxyBytecode);
 
-            expect(proxyBytecodeHash).to.be.equal('0xdec34d6bd2779b58de66dc79f2d80353e8cebb178d9afac4225bc3f652360aaa');
+            const expected = {
+                istanbul: '0x1eaf54a0dcc8ed839ba94f1ab33a4c9f63f6bf73959eb0cdd61627e699972aef',
+                berlin: '0x1d1dc288313dec7af9b83310f782bd9f24ab02030e6c7f67f6f510ee07a6d75b',
+                london: '0xdec34d6bd2779b58de66dc79f2d80353e8cebb178d9afac4225bc3f652360aaa',
+            }[EVM_VERSION]
+
+            expect(proxyBytecodeHash).to.be.equal(expected);
         });
     });
 });

--- a/test/AxelarDepositService.js
+++ b/test/AxelarDepositService.js
@@ -358,7 +358,7 @@ describe('AxelarDepositService', () => {
             ).to.changeEtherBalance(userWallet, amount);
         });
 
-        it('should have the same receiver bytecode', async () => {
+        it('should have the same receiver bytecode preserved for each EVM', async () => {
             const expected = {
                 istanbul: '0xc0fd88839756e97f51ab0395ce8e6164a5f924bd73a3342204340a14ad306fe1',
                 berlin: '0xc0fd88839756e97f51ab0395ce8e6164a5f924bd73a3342204340a14ad306fe1',
@@ -370,7 +370,7 @@ describe('AxelarDepositService', () => {
             );
         });
 
-        it('should have the same proxy bytecode', async () => {
+        it('should have the same proxy bytecode preserved for each EVM', async () => {
             const proxyBytecode = DepositServiceProxy.bytecode;
             const proxyBytecodeHash = keccak256(proxyBytecode);
 

--- a/test/AxelarGateway.js
+++ b/test/AxelarGateway.js
@@ -1,10 +1,12 @@
 const { sortBy } = require('lodash');
 const chai = require('chai');
-const { ethers } = require('hardhat');
+const { ethers, config } = require('hardhat');
 const {
     utils: { id, keccak256, getCreate2Address, defaultAbiCoder },
 } = ethers;
 const { expect } = chai;
+
+const EVM_VERSION = config.solidity.compilers[0].settings.evmVersion;
 
 const CHAIN_ID = 1;
 const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000';
@@ -730,20 +732,38 @@ describe('AxelarGateway', () => {
         });
 
         it('should have the same deposit handler bytecode', async () => {
+            const expected = {
+                istanbul: '0x352c0ce048c2b25b0b6a58f4695613b587f3086b63b4c3a24d22c043aed230d2',
+                berlin: '0xa26b1094ee475518c006cba8bd976fd4d3cd9a6089bcbe4453b1b4cf7f095609',
+                london: '0x9f217a79e864028081339cfcead3c3d1fe92e237fcbe9468d6bb4d1da7aa6352',
+            }[EVM_VERSION]
+
             await expect(keccak256(depositHandlerFactory.bytecode)).to.be.equal(
-              '0x9f217a79e864028081339cfcead3c3d1fe92e237fcbe9468d6bb4d1da7aa6352',
+              expected,
             );
         });
 
         it('should have the same token bytecode', async () => {
             const tokenFactory = await ethers.getContractFactory('BurnableMintableCappedERC20', owner);
 
+            const expectedToken = {
+                istanbul: '0xfc2522491a56af4f3519968ed49c9ba82abc79798afe8f763f601e7d5e14bdbf',
+                berlin: '0x81f6049561587bf700c0af132c504b22d696a6acfa606eee0257f92fd4ebd865',
+                london: '0x37be59a866fd46ec4179e243e5d5e2639ca1e842b152e45a34628dad6494b94b',
+            }[EVM_VERSION]
+
             await expect(keccak256(tokenFactory.bytecode)).to.be.equal(
-              '0x37be59a866fd46ec4179e243e5d5e2639ca1e842b152e45a34628dad6494b94b',
+              expectedToken,
             );
 
+            const expectedDeployer = {
+                istanbul: '0xc68014e297eb42dbde383254ef3129d59528159e6c51b4f9a38f995be1dd451f',
+                berlin: '0xd3a39792ca8d1ce8e5318135ca29d8a7f0b800837726997b132ebc04f88cf9aa',
+                london: '0x0698929742de660596af20d09d04eb91bfe532ef5e2927858e4c4952034967a5',
+            }[EVM_VERSION]
+
             await expect(keccak256(tokenDeployerFactory.bytecode)).to.be.equal(
-              '0x0698929742de660596af20d09d04eb91bfe532ef5e2927858e4c4952034967a5',
+              expectedDeployer,
             );
         });
     });

--- a/test/AxelarGateway.js
+++ b/test/AxelarGateway.js
@@ -209,6 +209,32 @@ describe('AxelarGateway', () => {
                 implementation.connect(admins[0]).upgrade(newGatewayImplementation.address, newGatewayImplementationCodeHash, params),
             ).to.be.revertedWith('NotAdmin()');
         });
+
+        it('should preserve the same proxy bytecode for each EVM', async () => {
+            const proxyBytecode = gatewayProxyFactory.bytecode;
+            const proxyBytecodeHash = keccak256(proxyBytecode);
+
+            const expected = {
+                istanbul: '0x6905e9ed2ee714532275d658b7cc3e3186acc52da48ffd499a2705a1185b8dde',
+                berlin: '0x374b511f48e03dfc872c49b1f3234785b50e4db2fb5eb135ef0c3f58b20c8b7a',
+                london: '0xcac4f10cb12909b2256570ae01df6fee5830b78afb230097fc401a69efa896cd',
+            }[EVM_VERSION]
+
+            expect(proxyBytecodeHash).to.be.equal(expected);
+        });
+
+        it('should preserve the implementation bytecode for each EVM', async () => {
+            const proxyBytecode = gatewayFactory.bytecode;
+            const proxyBytecodeHash = keccak256(proxyBytecode);
+
+            const expected = {
+                istanbul: '0x402fae9dea4f794e4974367713309309b21eedfb0255cf23343f368a53b1f47e',
+                berlin: '0x7b2d78a6c1c9c60a3fd1b784aa944dd1a5af372fb020fb5e499037e5cd6e52c4',
+                london: '0x9f807d086826e5944545772a21bb96784c6d9fe62b9a2b6dfd361974466c7f33',
+            }[EVM_VERSION]
+
+            expect(proxyBytecodeHash).to.be.equal(expected);
+        });
     });
 
     describe('execute', () => {
@@ -731,7 +757,7 @@ describe('AxelarGateway', () => {
                 });
         });
 
-        it('should have the same deposit handler bytecode', async () => {
+        it('should have the same deposit handler bytecode preserved for each EVM', async () => {
             const expected = {
                 istanbul: '0x352c0ce048c2b25b0b6a58f4695613b587f3086b63b4c3a24d22c043aed230d2',
                 berlin: '0xa26b1094ee475518c006cba8bd976fd4d3cd9a6089bcbe4453b1b4cf7f095609',
@@ -743,7 +769,7 @@ describe('AxelarGateway', () => {
             );
         });
 
-        it('should have the same token bytecode', async () => {
+        it('should have the same token bytecode preserved for each EVM', async () => {
             const tokenFactory = await ethers.getContractFactory('BurnableMintableCappedERC20', owner);
 
             const expectedToken = {

--- a/test/AxelarGateway.js
+++ b/test/AxelarGateway.js
@@ -728,6 +728,24 @@ describe('AxelarGateway', () => {
                     expect(balance).to.eq(0);
                 });
         });
+
+        it('should have the same deposit handler bytecode', async () => {
+            await expect(keccak256(depositHandlerFactory.bytecode)).to.be.equal(
+              '0x9f217a79e864028081339cfcead3c3d1fe92e237fcbe9468d6bb4d1da7aa6352',
+            );
+        });
+
+        it('should have the same token bytecode', async () => {
+            const tokenFactory = await ethers.getContractFactory('BurnableMintableCappedERC20', owner);
+
+            await expect(keccak256(tokenFactory.bytecode)).to.be.equal(
+              '0x37be59a866fd46ec4179e243e5d5e2639ca1e842b152e45a34628dad6494b94b',
+            );
+
+            await expect(keccak256(tokenDeployerFactory.bytecode)).to.be.equal(
+              '0x0698929742de660596af20d09d04eb91bfe532ef5e2927858e4c4952034967a5',
+            );
+        });
     });
 
     describe('command transferOperatorship', () => {

--- a/test/gmp/AxelarGasService.js
+++ b/test/gmp/AxelarGasService.js
@@ -1,12 +1,15 @@
 'use strict';
 
 const chai = require('chai');
+const { config, ethers} = require('hardhat');
 const {
     utils: { defaultAbiCoder, keccak256, parseEther },
-} = require('ethers');
+} = ethers;
 const { deployContract, MockProvider, solidity } = require('ethereum-waffle');
 chai.use(solidity);
 const { expect } = chai;
+
+const EVM_VERSION = config.solidity.compilers[0].settings.evmVersion;
 
 const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000';
 
@@ -344,8 +347,13 @@ describe('AxelarGasService', () => {
         it('should refund have the same proxy bytecode', async () => {
             const proxyBytecode = GasServiceProxy.bytecode;
             const proxyBytecodeHash = keccak256(proxyBytecode);
+            const expected = {
+                istanbul: '0x885390e8cdbd59403e862821e2cde97b65b8e0ff145ef131b7d1bb7b49ae575c',
+                berlin: '0x102a9449688476eff53daa30db95211709f2b78555415593d9bf4a2deb2ee92c',
+                london: '0x844ca3b3e4439c8473ba73c11d5c9b9bb69b6b528f8485a794797094724a4dbf',
+            }[EVM_VERSION]
 
-            expect(proxyBytecodeHash).to.be.equal('0x844ca3b3e4439c8473ba73c11d5c9b9bb69b6b528f8485a794797094724a4dbf');
+            expect(proxyBytecodeHash).to.be.equal(expected);
         });
     });
 });

--- a/test/gmp/AxelarGasService.js
+++ b/test/gmp/AxelarGasService.js
@@ -339,5 +339,13 @@ describe('AxelarGasService', () => {
                 .withArgs(txHash, logIndex, nativeGasFeeAmount, userWallet.address)
                 .and.to.changeEtherBalance(gasService, nativeGasFeeAmount);
         });
+
+
+        it('should refund have the same proxy bytecode', async () => {
+            const proxyBytecode = GasServiceProxy.bytecode;
+            const proxyBytecodeHash = keccak256(proxyBytecode);
+
+            expect(proxyBytecodeHash).to.be.equal('0x844ca3b3e4439c8473ba73c11d5c9b9bb69b6b528f8485a794797094724a4dbf');
+        });
     });
 });

--- a/test/gmp/AxelarGasService.js
+++ b/test/gmp/AxelarGasService.js
@@ -344,7 +344,7 @@ describe('AxelarGasService', () => {
         });
 
 
-        it('should refund have the same proxy bytecode', async () => {
+        it('should have the same proxy bytecode preserved for each EVM', async () => {
             const proxyBytecode = GasServiceProxy.bytecode;
             const proxyBytecodeHash = keccak256(proxyBytecode);
             const expected = {


### PR DESCRIPTION
- [x] `DepositService`, `GasService`: should preserve Proxy bytecode to get the same address across chains