### PR TITLE
feat: operators contract as per ticket axe680

### DIFF
--- a/contracts/interfaces/IOperators.sol
+++ b/contracts/interfaces/IOperators.sol
@@ -6,7 +6,7 @@ interface IOperators {
     error NotOperator();
     error InvalidOperator();
     error OperatorAlreadyAdded();
-    error OperatorAlreadyRemoved();
+    error NotAnOperator();
     error ExecutionFailed();
 
     event OperatorAdded(address indexed operator);

--- a/contracts/interfaces/IOperators.sol
+++ b/contracts/interfaces/IOperators.sol
@@ -9,14 +9,14 @@ interface IOperators {
     error OperatorAlreadyRemoved();
     error ExecutionFailed();
 
-    event OperatorAdded(address indexed newOperator);
-    event OperatorRemoved(address indexed oldOperator);
+    event OperatorAdded(address indexed operator);
+    event OperatorRemoved(address indexed operator);
 
-    function isOperator(address operator) external view returns (bool);
+    function isOperator(address account) external view returns (bool);
 
-    function addOperator(address newOperator) external;
+    function addOperator(address operator) external;
 
-    function removeOperator(address oldOperator) external;
+    function removeOperator(address operator) external;
 
-    function execute(address target, bytes calldata callData) external;
+    function execute(address target, bytes calldata callData) external returns (bytes memory);
 }

--- a/contracts/interfaces/IOperators.sol
+++ b/contracts/interfaces/IOperators.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.9;
+
+interface IOperators {
+    error NotOperator();
+    error InvalidOperator();
+    error OperatorAlreadyAdded();
+    error OperatorAlreadyRemoved();
+    error ExecutionFailed();
+
+    event OperatorAdded(address indexed newOperator);
+    event OperatorRemoved(address indexed oldOperator);
+
+    function isOperator(address operator) external view returns (bool);
+
+    function addOperator(address newOperator) external;
+
+    function removeOperator(address oldOperator) external;
+
+    function execute(address target, bytes calldata callData) external;
+}

--- a/contracts/test/TestOperators.sol
+++ b/contracts/test/TestOperators.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.9;
+
+contract TestOperators {
+    uint256 public num;
+
+    event NumAdded(uint256 num);
+
+    function setNum(uint256 _num) external returns (bool) {
+        num = _num;
+
+        emit NumAdded(_num);
+
+        return true;
+    }
+}

--- a/contracts/util/Operators.sol
+++ b/contracts/util/Operators.sol
@@ -30,7 +30,7 @@ contract Operators is Ownable, IOperators {
 
     function removeOperator(address operator) external onlyOwner {
         if (operator == address(0)) revert InvalidOperator();
-        if (!operators[operator]) revert OperatorAlreadyRemoved();
+        if (!operators[operator]) revert NotAnOperator();
 
         operators[operator] = false;
 

--- a/contracts/util/Operators.sol
+++ b/contracts/util/Operators.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.9;
+
+import { IOperators } from '../interfaces/IOperators.sol';
+import { Ownable } from '../Ownable.sol';
+
+contract Operators is Ownable, IOperators {
+    mapping(address => bool) public operators;
+
+    constructor() Ownable() {}
+
+    modifier onlyOperator() {
+        if (!operators[msg.sender]) revert NotOperator();
+        _;
+    }
+
+    function isOperator(address _operator) external view returns (bool) {
+        return operators[_operator];
+    }
+
+    function addOperator(address _newOperator) external onlyOwner {
+        if (_newOperator == address(0)) revert InvalidOperator();
+        if (operators[_newOperator]) revert OperatorAlreadyAdded();
+
+        operators[_newOperator] = true;
+
+        emit OperatorAdded(_newOperator);
+    }
+
+    function removeOperator(address _oldOperator) external onlyOwner {
+        if (_oldOperator == address(0)) revert InvalidOperator();
+        if (!operators[_oldOperator]) revert OperatorAlreadyRemoved();
+
+        operators[_oldOperator] = false;
+
+        emit OperatorRemoved(_oldOperator);
+    }
+
+    function execute(address target, bytes calldata callData) external onlyOperator {
+        (bool success, ) = target.call(callData);
+        if (!success) {
+            revert ExecutionFailed();
+        }
+    }
+}

--- a/contracts/util/Operators.sol
+++ b/contracts/util/Operators.sol
@@ -5,20 +5,46 @@ pragma solidity ^0.8.9;
 import { IOperators } from '../interfaces/IOperators.sol';
 import { Ownable } from '../Ownable.sol';
 
+/**
+ * @title Operators
+ * @dev Contract module which provides an access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions, and an operator that can execute arbitrary functions
+ * on any smart contract.
+ *
+ * The owner account is initially set as the deployer address.
+ */
 contract Operators is Ownable, IOperators {
     mapping(address => bool) public operators;
 
+    /**
+     * @dev Sets the deployer as the initial owner.
+     */
     constructor() Ownable() {}
 
+    /**
+     * @dev Modifier that requires the "msg.sender" to be an operator.
+     * Emits a NotOperator error if the condition is not met.
+     */
     modifier onlyOperator() {
         if (!operators[msg.sender]) revert NotOperator();
         _;
     }
 
+    /**
+     * @dev Returns whether an address is an operator.
+     * @param account Address to check
+     * @return boolean whether the address is an operator
+     */
     function isOperator(address account) external view returns (bool) {
         return operators[account];
     }
 
+    /**
+     * @dev Adds an address as an operator.
+     * Can only be called by the current owner.
+     * @param operator address to be added as operator
+     */
     function addOperator(address operator) external onlyOwner {
         if (operator == address(0)) revert InvalidOperator();
         if (operators[operator]) revert OperatorAlreadyAdded();
@@ -28,6 +54,11 @@ contract Operators is Ownable, IOperators {
         emit OperatorAdded(operator);
     }
 
+    /**
+     * @dev Removes an address as an operator.
+     * Can only be called by the current owner.
+     * @param operator address to be removed as operator
+     */
     function removeOperator(address operator) external onlyOwner {
         if (operator == address(0)) revert InvalidOperator();
         if (!operators[operator]) revert NotAnOperator();
@@ -37,7 +68,15 @@ contract Operators is Ownable, IOperators {
         emit OperatorRemoved(operator);
     }
 
+    /**
+     * @dev Allows an operator to execute arbitrary functions on any smart contract.
+     * Can only be called by an operator.
+     * @param target address of the contract to execute the function on
+     * @param callData ABI encoded function call to execute on target
+     * @return data return data from executed function call
+     */
     function execute(address target, bytes calldata callData) external onlyOperator returns (bytes memory) {
+        // solhint-disable-next-line avoid-low-level-calls
         (bool success, bytes memory data) = target.call(callData);
         if (!success) {
             revert ExecutionFailed();

--- a/contracts/util/Operators.sol
+++ b/contracts/util/Operators.sol
@@ -15,32 +15,34 @@ contract Operators is Ownable, IOperators {
         _;
     }
 
-    function isOperator(address _operator) external view returns (bool) {
-        return operators[_operator];
+    function isOperator(address account) external view returns (bool) {
+        return operators[account];
     }
 
-    function addOperator(address _newOperator) external onlyOwner {
-        if (_newOperator == address(0)) revert InvalidOperator();
-        if (operators[_newOperator]) revert OperatorAlreadyAdded();
+    function addOperator(address operator) external onlyOwner {
+        if (operator == address(0)) revert InvalidOperator();
+        if (operators[operator]) revert OperatorAlreadyAdded();
 
-        operators[_newOperator] = true;
+        operators[operator] = true;
 
-        emit OperatorAdded(_newOperator);
+        emit OperatorAdded(operator);
     }
 
-    function removeOperator(address _oldOperator) external onlyOwner {
-        if (_oldOperator == address(0)) revert InvalidOperator();
-        if (!operators[_oldOperator]) revert OperatorAlreadyRemoved();
+    function removeOperator(address operator) external onlyOwner {
+        if (operator == address(0)) revert InvalidOperator();
+        if (!operators[operator]) revert OperatorAlreadyRemoved();
 
-        operators[_oldOperator] = false;
+        operators[operator] = false;
 
-        emit OperatorRemoved(_oldOperator);
+        emit OperatorRemoved(operator);
     }
 
-    function execute(address target, bytes calldata callData) external onlyOperator {
-        (bool success, ) = target.call(callData);
+    function execute(address target, bytes calldata callData) external onlyOperator returns (bytes memory) {
+        (bool success, bytes memory data) = target.call(callData);
         if (!success) {
             revert ExecutionFailed();
         }
+
+        return data;
     }
 }

--- a/test/Operators.js
+++ b/test/Operators.js
@@ -1,0 +1,150 @@
+'use strict';
+
+const chai = require('chai');
+const { ethers } = require('hardhat');
+
+const { expect } = chai;
+
+describe('Operators', () => {
+    let ownerWallet;
+    let userWallet;
+    let operatorWallet;
+
+    let operatorsFactory;
+    let operators;
+
+    let testFactory;
+    let test;
+
+    before(async () => {
+        [ownerWallet, userWallet, operatorWallet] = await ethers.getSigners();
+
+        operatorsFactory = await ethers.getContractFactory('Operators', ownerWallet);
+        testFactory = await ethers.getContractFactory('TestOperators', ownerWallet);
+    });
+
+    beforeEach(async () => {
+        operators = await operatorsFactory.deploy().then((d) => d.deployed());
+        test = await testFactory.deploy().then((d) => d.deployed());
+    });
+
+    describe('owner actions', () => {
+        it('should set deployer address as owner', async () => {
+            expect(await operators.connect(ownerWallet).owner()).to.equal(ownerWallet.address);
+        });
+
+        it('should return false from isOperator for non operator address', async () => {
+            expect(await operators.connect(ownerWallet).isOperator(operatorWallet.address)).to.be.false;
+        });
+
+        it('should revert if non owner adds operator', async () => {
+            await expect(operators.connect(userWallet).addOperator(operatorWallet.address)).to.be.revertedWithCustomError(
+                operators,
+                'NotOwner',
+            );
+        });
+
+        it('should add an operator', async () => {
+            await expect(operators.connect(ownerWallet).addOperator(operatorWallet.address))
+                .to.emit(operators, 'OperatorAdded')
+                .withArgs(operatorWallet.address);
+        });
+
+        it('should return true from isOperator for operator address', async () => {
+            await operators.connect(ownerWallet).addOperator(operatorWallet.address);
+            expect(await operators.connect(ownerWallet).isOperator(operatorWallet.address)).to.be.true;
+        });
+
+        it('should revert when adding invalid operator address', async () => {
+            await expect(operators.connect(ownerWallet).addOperator(ethers.constants.AddressZero)).to.be.revertedWithCustomError(
+                operators,
+                'InvalidOperator',
+            );
+        });
+
+        it('should not add same operator twice', async () => {
+            await operators.connect(ownerWallet).addOperator(operatorWallet.address);
+
+            await expect(operators.connect(ownerWallet).addOperator(operatorWallet.address)).to.be.revertedWithCustomError(
+                operators,
+                'OperatorAlreadyAdded',
+            );
+        });
+
+        it('should revert if non owner removes operator', async () => {
+            await expect(operators.connect(userWallet).removeOperator(operatorWallet.address)).to.be.revertedWithCustomError(
+                operators,
+                'NotOwner',
+            );
+        });
+
+        it('should remove operator', async () => {
+            await operators.connect(ownerWallet).addOperator(operatorWallet.address);
+
+            await expect(operators.connect(ownerWallet).removeOperator(operatorWallet.address))
+                .to.emit(operators, 'OperatorRemoved')
+                .withArgs(operatorWallet.address);
+        });
+
+        it('should revert on remove operator with invalid address', async () => {
+            await expect(operators.connect(ownerWallet).removeOperator(ethers.constants.AddressZero)).to.be.revertedWithCustomError(
+                operators,
+                'InvalidOperator',
+            );
+        });
+
+        it('should revert when trying to remove non operator address', async () => {
+            await operators.connect(ownerWallet).addOperator(operatorWallet.address);
+
+            await expect(operators.connect(ownerWallet).removeOperator(userWallet.address)).to.be.revertedWithCustomError(
+                operators,
+                'NotAnOperator',
+            );
+        });
+    });
+
+    describe('operator actions', () => {
+        it('should revert when non operator calls execute', async () => {
+            await operators.connect(ownerWallet).addOperator(operatorWallet.address);
+
+            const target = test.address;
+            const num = 10;
+
+            const iface = new ethers.utils.Interface(['function setNum(uint256 _num) external returns (bool)']);
+
+            const callData = iface.encodeFunctionData('setNum', [num]);
+
+            await expect(operators.connect(ownerWallet).execute(target, callData)).to.be.revertedWithCustomError(operators, 'NotOperator');
+        });
+
+        it('should revert when execute fails', async () => {
+            await operators.connect(ownerWallet).addOperator(operatorWallet.address);
+
+            const target = test.address;
+            const num = 10;
+
+            // create typo in function name so execution fails
+            const iface = new ethers.utils.Interface(['function set(uint256 _num) external returns (bool)']);
+
+            const callData = iface.encodeFunctionData('set', [num]);
+
+            await expect(operators.connect(operatorWallet).execute(target, callData)).to.be.revertedWithCustomError(
+                operators,
+                'ExecutionFailed',
+            );
+        });
+
+        it('should call arbitrary function on another smart contract and return correct data', async () => {
+            await operators.connect(ownerWallet).addOperator(operatorWallet.address);
+
+            const target = test.address;
+            const num = 10;
+
+            const iface = new ethers.utils.Interface(['function setNum(uint256 _num) external returns (bool)']);
+
+            const callData = iface.encodeFunctionData('setNum', [num]);
+
+            await expect(operators.connect(operatorWallet).execute(target, callData)).to.emit(test, 'NumAdded').withArgs(num);
+        });
+    });
+});


### PR DESCRIPTION
Draft for the contract described in ticket AXE-680. It is a pretty straightforward implementation of having multiple operators any of whom can call any arbitrary contract. There is also onlyOwner functionality to add and remove operators.