### PR TITLE
fix: compute codehash correctly for polygon zkevm

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,10 +1,9 @@
 require('@nomicfoundation/hardhat-toolbox');
 
-const fs = require('fs');
 const env = process.env.ENV || 'testnet';
-const { importNetworks } = require('@axelar-network/axelar-contract-deployments/evm/utils');
+const { importNetworks, readJSON } = require('@axelar-network/axelar-contract-deployments/evm/utils');
 const chains = require(`@axelar-network/axelar-contract-deployments/info/${env}.json`);
-const keys = fs.existsSync(`${__dirname}/info/keys.json`) ? require(`${__dirname}/info/keys.json`) : undefined; // Load keys if they exist
+const keys = readJSON(`${__dirname}/info/keys.json`);
 const { networks, etherscan } = importNetworks(chains, keys);
 require('solidity-coverage');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@axelar-network/axelar-gmp-sdk-solidity": "^3.6.1"
       },
       "devDependencies": {
-        "@axelar-network/axelar-contract-deployments": "git://github.com/axelarnetwork/axelar-contract-deployments.git#7ca071fc69fb2cd39b175cdb92eb0e04b71acb15",
+        "@axelar-network/axelar-contract-deployments": "git://github.com/axelarnetwork/axelar-contract-deployments.git#68d0c9ee4b860f68045d8fe54f10c30f8aadc164",
         "@nomicfoundation/hardhat-toolbox": "^2.0.2",
         "chai": "^4.3.7",
         "cross-env": "^7.0.3",
@@ -33,12 +33,32 @@
         "node": "^16.0.0 || ^18.0.0"
       }
     },
+    "node_modules/@0xpolygonhermez/zkevm-commonjs": {
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/0xpolygonhermez/zkevm-commonjs.git#34f72fe9f7a4c3c45965742476a87148c9e05c0f",
+      "dev": true,
+      "license": "pending",
+      "dependencies": {
+        "@ethereumjs/block": "^3.6.2",
+        "@ethereumjs/tx": "^3.4.0",
+        "@polygon-hermez/common": "2.6.4",
+        "@polygon-hermez/vm": "5.7.30",
+        "ethereumjs-util": "^7.1.4",
+        "ethers": "^5.5.4",
+        "ffjavascript": "^0.2.55",
+        "lodash": "^4.17.21",
+        "pg": "^8.7.1"
+      }
+    },
     "node_modules/@axelar-network/axelar-contract-deployments": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/axelarnetwork/axelar-contract-deployments.git#7ca071fc69fb2cd39b175cdb92eb0e04b71acb15",
-      "integrity": "sha512-Hkp7LvKwQuHZtrxyvRJat+ze2DFl1AHTPUie79qq7JYGJXB7thZ/4QjVotLY3nq3KbpPdyKPGFgbtJwC99OYwg==",
+      "resolved": "git+ssh://git@github.com/axelarnetwork/axelar-contract-deployments.git#68d0c9ee4b860f68045d8fe54f10c30f8aadc164",
+      "integrity": "sha512-wpJb6yFdPtsJr0iNrGcLC8xM+mJpx55qfCNj/8ZbPfc84QXzxzVGyWT9UFYGZd/ky8llNBadhNE+iTb35oQ/Wg==",
       "dev": true,
       "license": "ISC",
+      "dependencies": {
+        "@0xpolygonhermez/zkevm-commonjs": "github:0xpolygonhermez/zkevm-commonjs#v1.0.0"
+      },
       "engines": {
         "node": "^16.0.0 || ^18.0.0"
       }
@@ -250,6 +270,67 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@ethereumjs/block": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/block/-/block-3.6.3.tgz",
+      "integrity": "sha512-CegDeryc2DVKnDkg5COQrE0bJfw/p0v3GBk2W5/Dj5dOVfEmb50Ux0GLnSPypooLnfqjwFaorGuT9FokWB3GRg==",
+      "dev": true,
+      "dependencies": {
+        "@ethereumjs/common": "^2.6.5",
+        "@ethereumjs/tx": "^3.5.2",
+        "ethereumjs-util": "^7.1.5",
+        "merkle-patricia-tree": "^4.2.4"
+      }
+    },
+    "node_modules/@ethereumjs/blockchain": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/blockchain/-/blockchain-5.5.3.tgz",
+      "integrity": "sha512-bi0wuNJ1gw4ByNCV56H0Z4Q7D+SxUbwyG12Wxzbvqc89PXLRNR20LBcSUZRKpN0+YCPo6m0XZL/JLio3B52LTw==",
+      "dev": true,
+      "dependencies": {
+        "@ethereumjs/block": "^3.6.2",
+        "@ethereumjs/common": "^2.6.4",
+        "@ethereumjs/ethash": "^1.1.0",
+        "debug": "^4.3.3",
+        "ethereumjs-util": "^7.1.5",
+        "level-mem": "^5.0.1",
+        "lru-cache": "^5.1.1",
+        "semaphore-async-await": "^1.5.1"
+      }
+    },
+    "node_modules/@ethereumjs/common": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.6.5.tgz",
+      "integrity": "sha512-lRyVQOeCDaIVtgfbowla32pzeDv2Obr8oR8Put5RdUBNRGr1VGPGQNGP6elWIpgK3YdpzqTOh4GyUGOureVeeA==",
+      "dev": true,
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "ethereumjs-util": "^7.1.5"
+      }
+    },
+    "node_modules/@ethereumjs/ethash": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/ethash/-/ethash-1.1.0.tgz",
+      "integrity": "sha512-/U7UOKW6BzpA+Vt+kISAoeDie1vAvY4Zy2KF5JJb+So7+1yKmJeJEHOGSnQIj330e9Zyl3L5Nae6VZyh2TJnAA==",
+      "dev": true,
+      "dependencies": {
+        "@ethereumjs/block": "^3.5.0",
+        "@types/levelup": "^4.3.0",
+        "buffer-xor": "^2.0.1",
+        "ethereumjs-util": "^7.1.1",
+        "miller-rabin": "^4.0.0"
+      }
+    },
+    "node_modules/@ethereumjs/tx": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-3.5.2.tgz",
+      "integrity": "sha512-gQDNJWKrSDGu2w7w0PzVXVBNMzb7wwdDOmOqczmhNjqFxFuIbhVJDwiGEnxFNC2/b8ifcZzY7MLcluizohRzNw==",
+      "dev": true,
+      "dependencies": {
+        "@ethereumjs/common": "^2.6.4",
+        "ethereumjs-util": "^7.1.5"
       }
     },
     "node_modules/@ethersproject/abi": {
@@ -1746,6 +1827,89 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/@polygon-hermez/common": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/@polygon-hermez/common/-/common-2.6.4.tgz",
+      "integrity": "sha512-ZGl/K1MaXHaDagqKCqkQgCRu9EfJ+mbK+t4GeVnDywMYGCyi7jF1u71Pyh4Rch3XFd/8rW/eVL4x4jkGwN16JQ==",
+      "dev": true,
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "ethereumjs-util": "^7.1.4"
+      }
+    },
+    "node_modules/@polygon-hermez/vm": {
+      "version": "5.7.30",
+      "resolved": "https://registry.npmjs.org/@polygon-hermez/vm/-/vm-5.7.30.tgz",
+      "integrity": "sha512-HxmrGuRpYsgwd4rnvYNQ4OR77OKdAbUsAD1Z6PoEvV18NHsMv6JGpMnvnSAseiCBCyqTHjnFqWynoQ1nl0Qr6g==",
+      "dev": true,
+      "dependencies": {
+        "@ethereumjs/block": "^3.6.1",
+        "@ethereumjs/blockchain": "^5.5.1",
+        "@ethereumjs/common": "^2.6.2",
+        "@ethereumjs/tx": "^3.5.0",
+        "@polygon-hermez/zkevm-commonjs": "github:hermeznetwork/zkevm-commonjs#v0.5.0.1",
+        "async-eventemitter": "^0.2.4",
+        "core-js-pure": "^3.0.1",
+        "debug": "^4.3.3",
+        "ethereumjs-util": "^7.1.4",
+        "ethers": "^5.6.2",
+        "functional-red-black-tree": "^1.0.1",
+        "lodash": "^4.17.21",
+        "mcl-wasm": "^0.7.1",
+        "merkle-patricia-tree": "^4.2.3",
+        "rustbn.js": "~0.2.0"
+      }
+    },
+    "node_modules/@polygon-hermez/zkevm-commonjs": {
+      "name": "@0xpolygonhermez/zkevm-commonjs",
+      "version": "0.5.0.1",
+      "resolved": "git+ssh://git@github.com/hermeznetwork/zkevm-commonjs.git#3ee798329f567fa19b7c4f1ffbcf3d91cf5bf273",
+      "dev": true,
+      "license": "pending",
+      "dependencies": {
+        "@ethereumjs/block": "^3.6.2",
+        "@ethereumjs/tx": "^3.4.0",
+        "@polygon-hermez/common": "2.6.3",
+        "@polygon-hermez/vm": "5.7.27",
+        "ethereumjs-util": "^7.1.4",
+        "ethers": "^5.5.4",
+        "ffjavascript": "^0.2.55",
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@polygon-hermez/zkevm-commonjs/node_modules/@polygon-hermez/common": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@polygon-hermez/common/-/common-2.6.3.tgz",
+      "integrity": "sha512-wLaod6WPquUm2sEE65XCiP4SFuJ8q3bd54Sb3h1yFZRr0MBx9GO8Rmr8Cmvj+EoQU9zJWJmZDp9aUcPWiA+uoA==",
+      "dev": true,
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "ethereumjs-util": "^7.1.4"
+      }
+    },
+    "node_modules/@polygon-hermez/zkevm-commonjs/node_modules/@polygon-hermez/vm": {
+      "version": "5.7.27",
+      "resolved": "https://registry.npmjs.org/@polygon-hermez/vm/-/vm-5.7.27.tgz",
+      "integrity": "sha512-7jjHP+GmixFEJv89i4S9JENf2bjs/y7kgZ6Jozy6UAhOvcjL+tobyZrrNvDWlNjzjxc/iu3mz3t3M3Ebp1qMBg==",
+      "dev": true,
+      "dependencies": {
+        "@ethereumjs/block": "^3.6.1",
+        "@ethereumjs/blockchain": "^5.5.1",
+        "@ethereumjs/common": "^2.6.2",
+        "@ethereumjs/tx": "^3.5.0",
+        "@polygon-hermez/zkevm-commonjs": "github:hermeznetwork/zkevm-commonjs#v0.0.26",
+        "async-eventemitter": "^0.2.4",
+        "core-js-pure": "^3.0.1",
+        "debug": "^4.3.3",
+        "ethereumjs-util": "^7.1.4",
+        "ethers": "^5.6.2",
+        "functional-red-black-tree": "^1.0.1",
+        "lodash": "^4.17.21",
+        "mcl-wasm": "^0.7.1",
+        "merkle-patricia-tree": "^4.2.3",
+        "rustbn.js": "~0.2.0"
+      }
+    },
     "node_modules/@scure/base": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
@@ -1985,6 +2149,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/@types/abstract-leveldown": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@types/abstract-leveldown/-/abstract-leveldown-7.2.1.tgz",
+      "integrity": "sha512-YK8irIC+eMrrmtGx0H4ISn9GgzLd9dojZWJaMbjp1YHLl2VqqNFBNrL5Q3KjGf4VE3sf/4hmq6EhQZ7kZp1NoQ==",
+      "dev": true
+    },
     "node_modules/@types/bn.js": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
@@ -2047,6 +2217,23 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/level-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/level-errors/-/level-errors-3.0.0.tgz",
+      "integrity": "sha512-/lMtoq/Cf/2DVOm6zE6ORyOM+3ZVm/BvzEZVxUhf6bgh8ZHglXlBqxbxSlJeVp8FCbD3IVvk/VbsaNmDjrQvqQ==",
+      "dev": true
+    },
+    "node_modules/@types/levelup": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@types/levelup/-/levelup-4.3.3.tgz",
+      "integrity": "sha512-K+OTIjJcZHVlZQN1HmU64VtrC0jC3dXWQozuEIR9zVvltIk90zaGPM2AgT+fIkChpzHhFE3YnvFLCbLtzAmexA==",
+      "dev": true,
+      "dependencies": {
+        "@types/abstract-leveldown": "*",
+        "@types/level-errors": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/lru-cache": {
       "version": "5.1.1",
@@ -2157,6 +2344,58 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/abstract-leveldown": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.3.0.tgz",
+      "integrity": "sha512-TU5nlYgta8YrBMNpc9FwQzRbiXsj49gsALsXadbGHt9CROPzX5fB0rWDR5mtdpOOKa5XqRFpbj1QroPAoPzVjQ==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "immediate": "^3.2.3",
+        "level-concat-iterator": "~2.0.0",
+        "level-supports": "~1.0.0",
+        "xtend": "~4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/abstract-leveldown/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/abstract-leveldown/node_modules/level-supports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
+      "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+      "dev": true,
+      "dependencies": {
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/acorn": {
@@ -2513,6 +2752,24 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/async-eventemitter": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
+      "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
+      "dev": true,
+      "dependencies": {
+        "async": "^2.4.0"
+      }
+    },
+    "node_modules/async-eventemitter/node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2762,6 +3019,24 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/buffer-xor": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.2.tgz",
+      "integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.1"
+      }
     },
     "node_modules/bufferutil": {
       "version": "4.0.6",
@@ -3322,6 +3597,17 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/core-js-pure": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.31.0.tgz",
+      "integrity": "sha512-/AnE9Y4OsJZicCzIe97JP5XoPKQJfTuEG43aEVLFJGOJpyqELod+pE6LEl63DfG1Mp8wX97LDaDpy1GmLEUxlg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -3512,6 +3798,71 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "node_modules/deferred-leveldown": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz",
+      "integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
+      "dev": true,
+      "dependencies": {
+        "abstract-leveldown": "~6.2.1",
+        "inherits": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deferred-leveldown/node_modules/abstract-leveldown": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+      "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "immediate": "^3.2.3",
+        "level-concat-iterator": "~2.0.0",
+        "level-supports": "~1.0.0",
+        "xtend": "~4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deferred-leveldown/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/deferred-leveldown/node_modules/level-supports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
+      "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+      "dev": true,
+      "dependencies": {
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/define-properties": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
@@ -3657,6 +4008,21 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/encoding-down": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
+      "integrity": "sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==",
+      "dev": true,
+      "dependencies": {
+        "abstract-leveldown": "^6.2.1",
+        "inherits": "^2.0.3",
+        "level-codec": "^9.0.0",
+        "level-errors": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/enquirer": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
@@ -3676,6 +4042,18 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/errno": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+      "dev": true,
+      "dependencies": {
+        "prr": "~1.0.1"
+      },
+      "bin": {
+        "errno": "cli.js"
       }
     },
     "node_modules/error-ex": {
@@ -5163,7 +5541,6 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
       "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/bn.js": "^5.1.0",
         "bn.js": "^5.1.2",
@@ -5356,6 +5733,17 @@
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/ffjavascript": {
+      "version": "0.2.59",
+      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.59.tgz",
+      "integrity": "sha512-QssOEUv+wilz9Sg7Zaj6KWAm7QceOAEsFuEBTltUsDo1cjn11rA/LGYvzFBPbzNfxRlZxwgJ7uxpCQcdDlrNfw==",
+      "dev": true,
+      "dependencies": {
+        "wasmbuilder": "0.0.16",
+        "wasmcurves": "0.2.1",
+        "web-worker": "^1.2.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -6487,6 +6875,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
+      "dev": true
+    },
     "node_modules/immutable": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
@@ -7069,6 +7463,103 @@
         "url": "https://opencollective.com/level"
       }
     },
+    "node_modules/level-codec": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
+      "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/level-codec/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/level-concat-iterator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
+      "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/level-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
+      "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
+      "dev": true,
+      "dependencies": {
+        "errno": "~0.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/level-iterator-stream": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz",
+      "integrity": "sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0",
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/level-mem": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/level-mem/-/level-mem-5.0.1.tgz",
+      "integrity": "sha512-qd+qUJHXsGSFoHTziptAKXoLX87QjR7v2KMbqncDXPxQuCdsQlzmyX+gwrEHhlzn08vkf8TyipYyMmiC6Gobzg==",
+      "dev": true,
+      "dependencies": {
+        "level-packager": "^5.0.3",
+        "memdown": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/level-packager": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.1.1.tgz",
+      "integrity": "sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==",
+      "dev": true,
+      "dependencies": {
+        "encoding-down": "^6.3.0",
+        "levelup": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/level-supports": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
@@ -7089,6 +7580,48 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/level-ws": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-2.0.0.tgz",
+      "integrity": "sha512-1iv7VXx0G9ec1isqQZ7y5LmoZo/ewAsyDHNA8EFDW5hqH2Kqovm33nSFkSdnLLAK+I5FlT+lo5Cw9itGe+CpQA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.0",
+        "xtend": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/levelup": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.4.0.tgz",
+      "integrity": "sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==",
+      "dev": true,
+      "dependencies": {
+        "deferred-leveldown": "~5.3.0",
+        "level-errors": "~2.0.0",
+        "level-iterator-stream": "~4.0.0",
+        "level-supports": "~1.0.0",
+        "xtend": "~4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/levelup/node_modules/level-supports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
+      "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+      "dev": true,
+      "dependencies": {
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/levn": {
@@ -7188,6 +7721,12 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/ltgt": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+      "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==",
+      "dev": true
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -7220,6 +7759,81 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/memdown": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-5.1.0.tgz",
+      "integrity": "sha512-B3J+UizMRAlEArDjWHTMmadet+UKwHd3UjMgGBkZcKAxAYVPS9o0Yeiha4qvz7iGiL2Sb3igUft6p7nbFWctpw==",
+      "dev": true,
+      "dependencies": {
+        "abstract-leveldown": "~6.2.1",
+        "functional-red-black-tree": "~1.0.1",
+        "immediate": "~3.2.3",
+        "inherits": "~2.0.1",
+        "ltgt": "~2.2.0",
+        "safe-buffer": "~5.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/memdown/node_modules/abstract-leveldown": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+      "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "immediate": "^3.2.3",
+        "level-concat-iterator": "~2.0.0",
+        "level-supports": "~1.0.0",
+        "xtend": "~4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/memdown/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/memdown/node_modules/immediate": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+      "integrity": "sha512-RrGCXRm/fRVqMIhqXrGEX9rRADavPiDFSoMb/k64i9XMk8uH4r/Omi5Ctierj6XzNecwDbO4WuFbDD1zmpl3Tg==",
+      "dev": true
+    },
+    "node_modules/memdown/node_modules/level-supports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
+      "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+      "dev": true,
+      "dependencies": {
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/memory-level": {
@@ -7255,6 +7869,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/merkle-patricia-tree": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-4.2.4.tgz",
+      "integrity": "sha512-eHbf/BG6eGNsqqfbLED9rIqbsF4+sykEaBn6OLNs71tjclbMcMOk1tEPmJKcNcNCLkvbpY/lwyOlizWsqPNo8w==",
+      "dev": true,
+      "dependencies": {
+        "@types/levelup": "^4.3.0",
+        "ethereumjs-util": "^7.1.4",
+        "level-mem": "^5.0.1",
+        "level-ws": "^2.0.0",
+        "readable-stream": "^3.6.0",
+        "semaphore-async-await": "^1.5.1"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -7268,6 +7896,25 @@
       "engines": {
         "node": ">=8.6"
       }
+    },
+    "node_modules/miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      }
+    },
+    "node_modules/miller-rabin/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -7841,6 +8488,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==",
+      "dev": true
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7952,6 +8605,97 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/pg": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.1.tgz",
+      "integrity": "sha512-utdq2obft07MxaDg0zBJI+l/M3mBRfIpEN3iSemsz0G5F2/VXx+XzqF4oxrbIZXQxt2AZzIUzyVg/YM6xOP/WQ==",
+      "dev": true,
+      "dependencies": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "^2.6.1",
+        "pg-pool": "^3.6.1",
+        "pg-protocol": "^1.6.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.1.1"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
+      "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.1.tgz",
+      "integrity": "sha512-w6ZzNu6oMmIzEAYVw+RLK0+nqHPt8K3ZnknKi+g48Ak2pr3dtljJW3o+D/n2zzCG07Zoe9VOX3aiKpj+BN0pjg==",
+      "dev": true
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.1.tgz",
+      "integrity": "sha512-jizsIzhkIitxCGfPRzJn1ZdcosIt3pz9Sh3V01fm1vZnbnCMgmGl5wvGGdNN2EL9Rmb0EcFoCkixH4Pu+sP9Og==",
+      "dev": true,
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
+      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q==",
+      "dev": true
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -7981,6 +8725,45 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -8111,6 +8894,12 @@
       "dependencies": {
         "asap": "~2.0.6"
       }
+    },
+    "node_modules/prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
+      "dev": true
     },
     "node_modules/psl": {
       "version": "1.8.0",
@@ -8752,6 +9541,15 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/semaphore-async-await": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/semaphore-async-await/-/semaphore-async-await-1.5.1.tgz",
+      "integrity": "sha512-b/ptP11hETwYWpeilHXXQiV5UJNJl7ZWWooKRE5eBIYWoom6dZ0SluCIdCtKycsMtZgKWE01/qAw6jblw1YVhg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.1"
       }
     },
     "node_modules/semver": {
@@ -9728,6 +10526,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -10619,6 +11426,27 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "node_modules/wasmbuilder": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/wasmbuilder/-/wasmbuilder-0.0.16.tgz",
+      "integrity": "sha512-Qx3lEFqaVvp1cEYW7Bfi+ebRJrOiwz2Ieu7ZG2l7YyeSJIok/reEQCQCuicj/Y32ITIJuGIM9xZQppGx5LrQdA==",
+      "dev": true
+    },
+    "node_modules/wasmcurves": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.2.1.tgz",
+      "integrity": "sha512-9ciO7bUE5bgpbOcdK7IO3enrSVIKHwrQmPibok4GLJWaCA7Wyqc9PRYnu5HbiFv9NDFNqVKPtU5R6Is5KujBLg==",
+      "dev": true,
+      "dependencies": {
+        "wasmbuilder": "0.0.16"
+      }
+    },
+    "node_modules/web-worker": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
+      "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==",
+      "dev": true
+    },
     "node_modules/web3-utils": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.9.0.tgz",
@@ -10815,6 +11643,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -10925,11 +11762,30 @@
     }
   },
   "dependencies": {
-    "@axelar-network/axelar-contract-deployments": {
-      "version": "git+ssh://git@github.com/axelarnetwork/axelar-contract-deployments.git#7ca071fc69fb2cd39b175cdb92eb0e04b71acb15",
-      "integrity": "sha512-Hkp7LvKwQuHZtrxyvRJat+ze2DFl1AHTPUie79qq7JYGJXB7thZ/4QjVotLY3nq3KbpPdyKPGFgbtJwC99OYwg==",
+    "@0xpolygonhermez/zkevm-commonjs": {
+      "version": "git+ssh://git@github.com/0xpolygonhermez/zkevm-commonjs.git#34f72fe9f7a4c3c45965742476a87148c9e05c0f",
       "dev": true,
-      "from": "@axelar-network/axelar-contract-deployments@git://github.com/axelarnetwork/axelar-contract-deployments.git#7ca071fc69fb2cd39b175cdb92eb0e04b71acb15"
+      "from": "@0xpolygonhermez/zkevm-commonjs@github:0xpolygonhermez/zkevm-commonjs#v1.0.0",
+      "requires": {
+        "@ethereumjs/block": "^3.6.2",
+        "@ethereumjs/tx": "^3.4.0",
+        "@polygon-hermez/common": "2.6.4",
+        "@polygon-hermez/vm": "5.7.30",
+        "ethereumjs-util": "^7.1.4",
+        "ethers": "^5.5.4",
+        "ffjavascript": "^0.2.55",
+        "lodash": "^4.17.21",
+        "pg": "^8.7.1"
+      }
+    },
+    "@axelar-network/axelar-contract-deployments": {
+      "version": "git+ssh://git@github.com/axelarnetwork/axelar-contract-deployments.git#68d0c9ee4b860f68045d8fe54f10c30f8aadc164",
+      "integrity": "sha512-wpJb6yFdPtsJr0iNrGcLC8xM+mJpx55qfCNj/8ZbPfc84QXzxzVGyWT9UFYGZd/ky8llNBadhNE+iTb35oQ/Wg==",
+      "dev": true,
+      "from": "@axelar-network/axelar-contract-deployments@git://github.com/axelarnetwork/axelar-contract-deployments.git#68d0c9ee4b860f68045d8fe54f10c30f8aadc164",
+      "requires": {
+        "@0xpolygonhermez/zkevm-commonjs": "github:0xpolygonhermez/zkevm-commonjs#v1.0.0"
+      }
     },
     "@axelar-network/axelar-gmp-sdk-solidity": {
       "version": "3.6.1",
@@ -11093,6 +11949,67 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.38.0.tgz",
       "integrity": "sha512-IoD2MfUnOV58ghIHCiil01PcohxjbYR/qCxsoC+xNgUwh1EY8jOOrYmu3d3a71+tJJ23uscEV4X2HJWMsPJu4g==",
       "dev": true
+    },
+    "@ethereumjs/block": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/block/-/block-3.6.3.tgz",
+      "integrity": "sha512-CegDeryc2DVKnDkg5COQrE0bJfw/p0v3GBk2W5/Dj5dOVfEmb50Ux0GLnSPypooLnfqjwFaorGuT9FokWB3GRg==",
+      "dev": true,
+      "requires": {
+        "@ethereumjs/common": "^2.6.5",
+        "@ethereumjs/tx": "^3.5.2",
+        "ethereumjs-util": "^7.1.5",
+        "merkle-patricia-tree": "^4.2.4"
+      }
+    },
+    "@ethereumjs/blockchain": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/blockchain/-/blockchain-5.5.3.tgz",
+      "integrity": "sha512-bi0wuNJ1gw4ByNCV56H0Z4Q7D+SxUbwyG12Wxzbvqc89PXLRNR20LBcSUZRKpN0+YCPo6m0XZL/JLio3B52LTw==",
+      "dev": true,
+      "requires": {
+        "@ethereumjs/block": "^3.6.2",
+        "@ethereumjs/common": "^2.6.4",
+        "@ethereumjs/ethash": "^1.1.0",
+        "debug": "^4.3.3",
+        "ethereumjs-util": "^7.1.5",
+        "level-mem": "^5.0.1",
+        "lru-cache": "^5.1.1",
+        "semaphore-async-await": "^1.5.1"
+      }
+    },
+    "@ethereumjs/common": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.6.5.tgz",
+      "integrity": "sha512-lRyVQOeCDaIVtgfbowla32pzeDv2Obr8oR8Put5RdUBNRGr1VGPGQNGP6elWIpgK3YdpzqTOh4GyUGOureVeeA==",
+      "dev": true,
+      "requires": {
+        "crc-32": "^1.2.0",
+        "ethereumjs-util": "^7.1.5"
+      }
+    },
+    "@ethereumjs/ethash": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/ethash/-/ethash-1.1.0.tgz",
+      "integrity": "sha512-/U7UOKW6BzpA+Vt+kISAoeDie1vAvY4Zy2KF5JJb+So7+1yKmJeJEHOGSnQIj330e9Zyl3L5Nae6VZyh2TJnAA==",
+      "dev": true,
+      "requires": {
+        "@ethereumjs/block": "^3.5.0",
+        "@types/levelup": "^4.3.0",
+        "buffer-xor": "^2.0.1",
+        "ethereumjs-util": "^7.1.1",
+        "miller-rabin": "^4.0.0"
+      }
+    },
+    "@ethereumjs/tx": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-3.5.2.tgz",
+      "integrity": "sha512-gQDNJWKrSDGu2w7w0PzVXVBNMzb7wwdDOmOqczmhNjqFxFuIbhVJDwiGEnxFNC2/b8ifcZzY7MLcluizohRzNw==",
+      "dev": true,
+      "requires": {
+        "@ethereumjs/common": "^2.6.4",
+        "ethereumjs-util": "^7.1.5"
+      }
     },
     "@ethersproject/abi": {
       "version": "5.7.0",
@@ -12064,6 +12981,89 @@
         }
       }
     },
+    "@polygon-hermez/common": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/@polygon-hermez/common/-/common-2.6.4.tgz",
+      "integrity": "sha512-ZGl/K1MaXHaDagqKCqkQgCRu9EfJ+mbK+t4GeVnDywMYGCyi7jF1u71Pyh4Rch3XFd/8rW/eVL4x4jkGwN16JQ==",
+      "dev": true,
+      "requires": {
+        "crc-32": "^1.2.0",
+        "ethereumjs-util": "^7.1.4"
+      }
+    },
+    "@polygon-hermez/vm": {
+      "version": "5.7.30",
+      "resolved": "https://registry.npmjs.org/@polygon-hermez/vm/-/vm-5.7.30.tgz",
+      "integrity": "sha512-HxmrGuRpYsgwd4rnvYNQ4OR77OKdAbUsAD1Z6PoEvV18NHsMv6JGpMnvnSAseiCBCyqTHjnFqWynoQ1nl0Qr6g==",
+      "dev": true,
+      "requires": {
+        "@ethereumjs/block": "^3.6.1",
+        "@ethereumjs/blockchain": "^5.5.1",
+        "@ethereumjs/common": "^2.6.2",
+        "@ethereumjs/tx": "^3.5.0",
+        "@polygon-hermez/zkevm-commonjs": "github:hermeznetwork/zkevm-commonjs#v0.5.0.1",
+        "async-eventemitter": "^0.2.4",
+        "core-js-pure": "^3.0.1",
+        "debug": "^4.3.3",
+        "ethereumjs-util": "^7.1.4",
+        "ethers": "^5.6.2",
+        "functional-red-black-tree": "^1.0.1",
+        "lodash": "^4.17.21",
+        "mcl-wasm": "^0.7.1",
+        "merkle-patricia-tree": "^4.2.3",
+        "rustbn.js": "~0.2.0"
+      }
+    },
+    "@polygon-hermez/zkevm-commonjs": {
+      "version": "git+ssh://git@github.com/hermeznetwork/zkevm-commonjs.git#3ee798329f567fa19b7c4f1ffbcf3d91cf5bf273",
+      "dev": true,
+      "from": "@polygon-hermez/zkevm-commonjs@github:hermeznetwork/zkevm-commonjs#v0.5.0.1",
+      "requires": {
+        "@ethereumjs/block": "^3.6.2",
+        "@ethereumjs/tx": "^3.4.0",
+        "@polygon-hermez/common": "2.6.3",
+        "@polygon-hermez/vm": "5.7.27",
+        "ethereumjs-util": "^7.1.4",
+        "ethers": "^5.5.4",
+        "ffjavascript": "^0.2.55",
+        "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "@polygon-hermez/common": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/@polygon-hermez/common/-/common-2.6.3.tgz",
+          "integrity": "sha512-wLaod6WPquUm2sEE65XCiP4SFuJ8q3bd54Sb3h1yFZRr0MBx9GO8Rmr8Cmvj+EoQU9zJWJmZDp9aUcPWiA+uoA==",
+          "dev": true,
+          "requires": {
+            "crc-32": "^1.2.0",
+            "ethereumjs-util": "^7.1.4"
+          }
+        },
+        "@polygon-hermez/vm": {
+          "version": "5.7.27",
+          "resolved": "https://registry.npmjs.org/@polygon-hermez/vm/-/vm-5.7.27.tgz",
+          "integrity": "sha512-7jjHP+GmixFEJv89i4S9JENf2bjs/y7kgZ6Jozy6UAhOvcjL+tobyZrrNvDWlNjzjxc/iu3mz3t3M3Ebp1qMBg==",
+          "dev": true,
+          "requires": {
+            "@ethereumjs/block": "^3.6.1",
+            "@ethereumjs/blockchain": "^5.5.1",
+            "@ethereumjs/common": "^2.6.2",
+            "@ethereumjs/tx": "^3.5.0",
+            "@polygon-hermez/zkevm-commonjs": "github:hermeznetwork/zkevm-commonjs#v0.0.26",
+            "async-eventemitter": "^0.2.4",
+            "core-js-pure": "^3.0.1",
+            "debug": "^4.3.3",
+            "ethereumjs-util": "^7.1.4",
+            "ethers": "^5.6.2",
+            "functional-red-black-tree": "^1.0.1",
+            "lodash": "^4.17.21",
+            "mcl-wasm": "^0.7.1",
+            "merkle-patricia-tree": "^4.2.3",
+            "rustbn.js": "~0.2.0"
+          }
+        }
+      }
+    },
     "@scure/base": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
@@ -12247,6 +13247,12 @@
         }
       }
     },
+    "@types/abstract-leveldown": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@types/abstract-leveldown/-/abstract-leveldown-7.2.1.tgz",
+      "integrity": "sha512-YK8irIC+eMrrmtGx0H4ISn9GgzLd9dojZWJaMbjp1YHLl2VqqNFBNrL5Q3KjGf4VE3sf/4hmq6EhQZ7kZp1NoQ==",
+      "dev": true
+    },
     "@types/bn.js": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
@@ -12309,6 +13315,23 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "@types/level-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/level-errors/-/level-errors-3.0.0.tgz",
+      "integrity": "sha512-/lMtoq/Cf/2DVOm6zE6ORyOM+3ZVm/BvzEZVxUhf6bgh8ZHglXlBqxbxSlJeVp8FCbD3IVvk/VbsaNmDjrQvqQ==",
+      "dev": true
+    },
+    "@types/levelup": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@types/levelup/-/levelup-4.3.3.tgz",
+      "integrity": "sha512-K+OTIjJcZHVlZQN1HmU64VtrC0jC3dXWQozuEIR9zVvltIk90zaGPM2AgT+fIkChpzHhFE3YnvFLCbLtzAmexA==",
+      "dev": true,
+      "requires": {
+        "@types/abstract-leveldown": "*",
+        "@types/level-errors": "*",
+        "@types/node": "*"
+      }
     },
     "@types/lru-cache": {
       "version": "5.1.1",
@@ -12415,6 +13438,40 @@
         "level-transcoder": "^1.0.1",
         "module-error": "^1.0.1",
         "queue-microtask": "^1.2.3"
+      }
+    },
+    "abstract-leveldown": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.3.0.tgz",
+      "integrity": "sha512-TU5nlYgta8YrBMNpc9FwQzRbiXsj49gsALsXadbGHt9CROPzX5fB0rWDR5mtdpOOKa5XqRFpbj1QroPAoPzVjQ==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "immediate": "^3.2.3",
+        "level-concat-iterator": "~2.0.0",
+        "level-supports": "~1.0.0",
+        "xtend": "~4.0.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
+        "level-supports": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
+          "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+          "dev": true,
+          "requires": {
+            "xtend": "^4.0.2"
+          }
+        }
       }
     },
     "acorn": {
@@ -12677,6 +13734,26 @@
       "dev": true,
       "peer": true
     },
+    "async-eventemitter": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
+      "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
+      "dev": true,
+      "requires": {
+        "async": "^2.4.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        }
+      }
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -12884,6 +13961,21 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
+      "dev": true
+    },
+    "buffer-xor": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.2.tgz",
+      "integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.1"
+      }
     },
     "bufferutil": {
       "version": "4.0.6",
@@ -13329,6 +14421,12 @@
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
       "dev": true
     },
+    "core-js-pure": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.31.0.tgz",
+      "integrity": "sha512-/AnE9Y4OsJZicCzIe97JP5XoPKQJfTuEG43aEVLFJGOJpyqELod+pE6LEl63DfG1Mp8wX97LDaDpy1GmLEUxlg==",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -13469,6 +14567,50 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "deferred-leveldown": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz",
+      "integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
+      "dev": true,
+      "requires": {
+        "abstract-leveldown": "~6.2.1",
+        "inherits": "^2.0.3"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+          "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "immediate": "^3.2.3",
+            "level-concat-iterator": "~2.0.0",
+            "level-supports": "~1.0.0",
+            "xtend": "~4.0.0"
+          }
+        },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
+        "level-supports": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
+          "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+          "dev": true,
+          "requires": {
+            "xtend": "^4.0.2"
+          }
+        }
+      }
+    },
     "define-properties": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
@@ -13585,6 +14727,18 @@
       "dev": true,
       "peer": true
     },
+    "encoding-down": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
+      "integrity": "sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==",
+      "dev": true,
+      "requires": {
+        "abstract-leveldown": "^6.2.1",
+        "inherits": "^2.0.3",
+        "level-codec": "^9.0.0",
+        "level-errors": "^2.0.0"
+      }
+    },
     "enquirer": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
@@ -13599,6 +14753,15 @@
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true
+    },
+    "errno": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+      "dev": true,
+      "requires": {
+        "prr": "~1.0.1"
+      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -14764,7 +15927,6 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
       "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@types/bn.js": "^5.1.0",
         "bn.js": "^5.1.2",
@@ -14928,6 +16090,17 @@
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
+      }
+    },
+    "ffjavascript": {
+      "version": "0.2.59",
+      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.59.tgz",
+      "integrity": "sha512-QssOEUv+wilz9Sg7Zaj6KWAm7QceOAEsFuEBTltUsDo1cjn11rA/LGYvzFBPbzNfxRlZxwgJ7uxpCQcdDlrNfw==",
+      "dev": true,
+      "requires": {
+        "wasmbuilder": "0.0.16",
+        "wasmcurves": "0.2.1",
+        "web-worker": "^1.2.0"
       }
     },
     "file-entry-cache": {
@@ -15790,6 +16963,12 @@
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true
     },
+    "immediate": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
+      "dev": true
+    },
     "immutable": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
@@ -16214,6 +17393,73 @@
         "classic-level": "^1.2.0"
       }
     },
+    "level-codec": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
+      "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.6.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
+      }
+    },
+    "level-concat-iterator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
+      "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw==",
+      "dev": true
+    },
+    "level-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
+      "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
+      "dev": true,
+      "requires": {
+        "errno": "~0.1.1"
+      }
+    },
+    "level-iterator-stream": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz",
+      "integrity": "sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0",
+        "xtend": "^4.0.2"
+      }
+    },
+    "level-mem": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/level-mem/-/level-mem-5.0.1.tgz",
+      "integrity": "sha512-qd+qUJHXsGSFoHTziptAKXoLX87QjR7v2KMbqncDXPxQuCdsQlzmyX+gwrEHhlzn08vkf8TyipYyMmiC6Gobzg==",
+      "dev": true,
+      "requires": {
+        "level-packager": "^5.0.3",
+        "memdown": "^5.0.0"
+      }
+    },
+    "level-packager": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.1.1.tgz",
+      "integrity": "sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==",
+      "dev": true,
+      "requires": {
+        "encoding-down": "^6.3.0",
+        "levelup": "^4.3.2"
+      }
+    },
     "level-supports": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
@@ -16228,6 +17474,41 @@
       "requires": {
         "buffer": "^6.0.3",
         "module-error": "^1.0.1"
+      }
+    },
+    "level-ws": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-2.0.0.tgz",
+      "integrity": "sha512-1iv7VXx0G9ec1isqQZ7y5LmoZo/ewAsyDHNA8EFDW5hqH2Kqovm33nSFkSdnLLAK+I5FlT+lo5Cw9itGe+CpQA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.0",
+        "xtend": "^4.0.1"
+      }
+    },
+    "levelup": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.4.0.tgz",
+      "integrity": "sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==",
+      "dev": true,
+      "requires": {
+        "deferred-leveldown": "~5.3.0",
+        "level-errors": "~2.0.0",
+        "level-iterator-stream": "~4.0.0",
+        "level-supports": "~1.0.0",
+        "xtend": "~4.0.0"
+      },
+      "dependencies": {
+        "level-supports": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
+          "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+          "dev": true,
+          "requires": {
+            "xtend": "^4.0.2"
+          }
+        }
       }
     },
     "levn": {
@@ -16315,6 +17596,12 @@
         "yallist": "^3.0.2"
       }
     },
+    "ltgt": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+      "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==",
+      "dev": true
+    },
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -16346,6 +17633,60 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "memdown": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-5.1.0.tgz",
+      "integrity": "sha512-B3J+UizMRAlEArDjWHTMmadet+UKwHd3UjMgGBkZcKAxAYVPS9o0Yeiha4qvz7iGiL2Sb3igUft6p7nbFWctpw==",
+      "dev": true,
+      "requires": {
+        "abstract-leveldown": "~6.2.1",
+        "functional-red-black-tree": "~1.0.1",
+        "immediate": "~3.2.3",
+        "inherits": "~2.0.1",
+        "ltgt": "~2.2.0",
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+          "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "immediate": "^3.2.3",
+            "level-concat-iterator": "~2.0.0",
+            "level-supports": "~1.0.0",
+            "xtend": "~4.0.0"
+          }
+        },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
+        "immediate": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+          "integrity": "sha512-RrGCXRm/fRVqMIhqXrGEX9rRADavPiDFSoMb/k64i9XMk8uH4r/Omi5Ctierj6XzNecwDbO4WuFbDD1zmpl3Tg==",
+          "dev": true
+        },
+        "level-supports": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
+          "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+          "dev": true,
+          "requires": {
+            "xtend": "^4.0.2"
+          }
+        }
+      }
+    },
     "memory-level": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/memory-level/-/memory-level-1.0.0.tgz",
@@ -16370,6 +17711,20 @@
       "dev": true,
       "peer": true
     },
+    "merkle-patricia-tree": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-4.2.4.tgz",
+      "integrity": "sha512-eHbf/BG6eGNsqqfbLED9rIqbsF4+sykEaBn6OLNs71tjclbMcMOk1tEPmJKcNcNCLkvbpY/lwyOlizWsqPNo8w==",
+      "dev": true,
+      "requires": {
+        "@types/levelup": "^4.3.0",
+        "ethereumjs-util": "^7.1.4",
+        "level-mem": "^5.0.1",
+        "level-ws": "^2.0.0",
+        "readable-stream": "^3.6.0",
+        "semaphore-async-await": "^1.5.1"
+      }
+    },
     "micromatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -16379,6 +17734,24 @@
       "requires": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
+      }
+    },
+    "miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        }
       }
     },
     "mime-db": {
@@ -16816,6 +18189,12 @@
       "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
       "dev": true
     },
+    "packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==",
+      "dev": true
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -16900,6 +18279,76 @@
       "dev": true,
       "peer": true
     },
+    "pg": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.1.tgz",
+      "integrity": "sha512-utdq2obft07MxaDg0zBJI+l/M3mBRfIpEN3iSemsz0G5F2/VXx+XzqF4oxrbIZXQxt2AZzIUzyVg/YM6xOP/WQ==",
+      "dev": true,
+      "requires": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-cloudflare": "^1.1.1",
+        "pg-connection-string": "^2.6.1",
+        "pg-pool": "^3.6.1",
+        "pg-protocol": "^1.6.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      }
+    },
+    "pg-cloudflare": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
+      "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==",
+      "dev": true,
+      "optional": true
+    },
+    "pg-connection-string": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.1.tgz",
+      "integrity": "sha512-w6ZzNu6oMmIzEAYVw+RLK0+nqHPt8K3ZnknKi+g48Ak2pr3dtljJW3o+D/n2zzCG07Zoe9VOX3aiKpj+BN0pjg==",
+      "dev": true
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true
+    },
+    "pg-pool": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.1.tgz",
+      "integrity": "sha512-jizsIzhkIitxCGfPRzJn1ZdcosIt3pz9Sh3V01fm1vZnbnCMgmGl5wvGGdNN2EL9Rmb0EcFoCkixH4Pu+sP9Og==",
+      "dev": true,
+      "requires": {}
+    },
+    "pg-protocol": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
+      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q==",
+      "dev": true
+    },
+    "pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "requires": {
+        "split2": "^4.1.0"
+      }
+    },
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -16918,6 +18367,33 @@
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
       "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
       "dev": true
+    },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "dev": true
+    },
+    "postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "requires": {
+        "xtend": "^4.0.0"
+      }
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -17018,6 +18494,12 @@
       "requires": {
         "asap": "~2.0.6"
       }
+    },
+    "prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
+      "dev": true
     },
     "psl": {
       "version": "1.8.0",
@@ -17477,6 +18959,12 @@
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0"
       }
+    },
+    "semaphore-async-await": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/semaphore-async-await/-/semaphore-async-await-1.5.1.tgz",
+      "integrity": "sha512-b/ptP11hETwYWpeilHXXQiV5UJNJl7ZWWooKRE5eBIYWoom6dZ0SluCIdCtKycsMtZgKWE01/qAw6jblw1YVhg==",
+      "dev": true
     },
     "semver": {
       "version": "6.3.0",
@@ -18254,6 +19742,12 @@
         }
       }
     },
+    "split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -18947,6 +20441,27 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "wasmbuilder": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/wasmbuilder/-/wasmbuilder-0.0.16.tgz",
+      "integrity": "sha512-Qx3lEFqaVvp1cEYW7Bfi+ebRJrOiwz2Ieu7ZG2l7YyeSJIok/reEQCQCuicj/Y32ITIJuGIM9xZQppGx5LrQdA==",
+      "dev": true
+    },
+    "wasmcurves": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.2.1.tgz",
+      "integrity": "sha512-9ciO7bUE5bgpbOcdK7IO3enrSVIKHwrQmPibok4GLJWaCA7Wyqc9PRYnu5HbiFv9NDFNqVKPtU5R6Is5KujBLg==",
+      "dev": true,
+      "requires": {
+        "wasmbuilder": "0.0.16"
+      }
+    },
+    "web-worker": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
+      "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==",
+      "dev": true
+    },
     "web3-utils": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.9.0.tgz",
@@ -19096,6 +20611,12 @@
       "integrity": "sha512-58Im/U0mlVBLM38NdZjHyhuMtCqa61469k2YP/AaPbvCoV9aQGUpbJBj1QRm2ytRiVQBD/fsw7L2bJGDVQswBA==",
       "dev": true,
       "peer": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
     },
     "y18n": {
       "version": "5.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@axelar-network/axelar-gmp-sdk-solidity": "^3.6.1"
       },
       "devDependencies": {
-        "@axelar-network/axelar-contract-deployments": "git://github.com/axelarnetwork/axelar-contract-deployments.git#68d0c9ee4b860f68045d8fe54f10c30f8aadc164",
+        "@axelar-network/axelar-contract-deployments": "git://github.com/axelarnetwork/axelar-contract-deployments.git#4a5cd497d827672458bdfa1d7eb746eebb91cca2",
         "@nomicfoundation/hardhat-toolbox": "^2.0.2",
         "chai": "^4.3.7",
         "cross-env": "^7.0.3",
@@ -52,8 +52,8 @@
     },
     "node_modules/@axelar-network/axelar-contract-deployments": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/axelarnetwork/axelar-contract-deployments.git#68d0c9ee4b860f68045d8fe54f10c30f8aadc164",
-      "integrity": "sha512-wpJb6yFdPtsJr0iNrGcLC8xM+mJpx55qfCNj/8ZbPfc84QXzxzVGyWT9UFYGZd/ky8llNBadhNE+iTb35oQ/Wg==",
+      "resolved": "git+ssh://git@github.com/axelarnetwork/axelar-contract-deployments.git#4a5cd497d827672458bdfa1d7eb746eebb91cca2",
+      "integrity": "sha512-YompC/P9G1QpP2yeM4XXwzqJRZAmkMzBBz6fkk+eGdSbilvvXKXR6SwlZnl1IYvP3HkQejJMPu5uV1bfktlRlQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -11779,10 +11779,10 @@
       }
     },
     "@axelar-network/axelar-contract-deployments": {
-      "version": "git+ssh://git@github.com/axelarnetwork/axelar-contract-deployments.git#68d0c9ee4b860f68045d8fe54f10c30f8aadc164",
-      "integrity": "sha512-wpJb6yFdPtsJr0iNrGcLC8xM+mJpx55qfCNj/8ZbPfc84QXzxzVGyWT9UFYGZd/ky8llNBadhNE+iTb35oQ/Wg==",
+      "version": "git+ssh://git@github.com/axelarnetwork/axelar-contract-deployments.git#4a5cd497d827672458bdfa1d7eb746eebb91cca2",
+      "integrity": "sha512-YompC/P9G1QpP2yeM4XXwzqJRZAmkMzBBz6fkk+eGdSbilvvXKXR6SwlZnl1IYvP3HkQejJMPu5uV1bfktlRlQ==",
       "dev": true,
-      "from": "@axelar-network/axelar-contract-deployments@git://github.com/axelarnetwork/axelar-contract-deployments.git#68d0c9ee4b860f68045d8fe54f10c30f8aadc164",
+      "from": "@axelar-network/axelar-contract-deployments@git://github.com/axelarnetwork/axelar-contract-deployments.git#4a5cd497d827672458bdfa1d7eb746eebb91cca2",
       "requires": {
         "@0xpolygonhermez/zkevm-commonjs": "github:0xpolygonhermez/zkevm-commonjs#v1.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@axelar-network/axelar-gmp-sdk-solidity": "^3.6.1"
       },
       "devDependencies": {
-        "@axelar-network/axelar-contract-deployments": "git://github.com/axelarnetwork/axelar-contract-deployments.git#4a5cd497d827672458bdfa1d7eb746eebb91cca2",
+        "@axelar-network/axelar-contract-deployments": "git://github.com/axelarnetwork/axelar-contract-deployments.git#74b942fdf10875a27b532d9bd6dfe2bd6db8a094",
         "@nomicfoundation/hardhat-toolbox": "^2.0.2",
         "chai": "^4.3.7",
         "cross-env": "^7.0.3",
@@ -52,8 +52,8 @@
     },
     "node_modules/@axelar-network/axelar-contract-deployments": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/axelarnetwork/axelar-contract-deployments.git#4a5cd497d827672458bdfa1d7eb746eebb91cca2",
-      "integrity": "sha512-YompC/P9G1QpP2yeM4XXwzqJRZAmkMzBBz6fkk+eGdSbilvvXKXR6SwlZnl1IYvP3HkQejJMPu5uV1bfktlRlQ==",
+      "resolved": "git+ssh://git@github.com/axelarnetwork/axelar-contract-deployments.git#74b942fdf10875a27b532d9bd6dfe2bd6db8a094",
+      "integrity": "sha512-PjvXhJSjvNy4Ah3V/PfEPZi1BQaFEeIVV5zluKMNuZnlT0hr9srBvSQro1giOzP6Ex4kAIOkWFFgSMPs2YeczA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -11779,10 +11779,10 @@
       }
     },
     "@axelar-network/axelar-contract-deployments": {
-      "version": "git+ssh://git@github.com/axelarnetwork/axelar-contract-deployments.git#4a5cd497d827672458bdfa1d7eb746eebb91cca2",
-      "integrity": "sha512-YompC/P9G1QpP2yeM4XXwzqJRZAmkMzBBz6fkk+eGdSbilvvXKXR6SwlZnl1IYvP3HkQejJMPu5uV1bfktlRlQ==",
+      "version": "git+ssh://git@github.com/axelarnetwork/axelar-contract-deployments.git#74b942fdf10875a27b532d9bd6dfe2bd6db8a094",
+      "integrity": "sha512-PjvXhJSjvNy4Ah3V/PfEPZi1BQaFEeIVV5zluKMNuZnlT0hr9srBvSQro1giOzP6Ex4kAIOkWFFgSMPs2YeczA==",
       "dev": true,
-      "from": "@axelar-network/axelar-contract-deployments@git://github.com/axelarnetwork/axelar-contract-deployments.git#4a5cd497d827672458bdfa1d7eb746eebb91cca2",
+      "from": "@axelar-network/axelar-contract-deployments@git://github.com/axelarnetwork/axelar-contract-deployments.git#74b942fdf10875a27b532d9bd6dfe2bd6db8a094",
       "requires": {
         "@0xpolygonhermez/zkevm-commonjs": "github:0xpolygonhermez/zkevm-commonjs#v1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@axelar-network/axelar-gmp-sdk-solidity": "^3.6.1"
   },
   "devDependencies": {
-    "@axelar-network/axelar-contract-deployments": "git://github.com/axelarnetwork/axelar-contract-deployments.git#7ca071fc69fb2cd39b175cdb92eb0e04b71acb15",
+    "@axelar-network/axelar-contract-deployments": "git://github.com/axelarnetwork/axelar-contract-deployments.git#68d0c9ee4b860f68045d8fe54f10c30f8aadc164",
     "@nomicfoundation/hardhat-toolbox": "^2.0.2",
     "chai": "^4.3.7",
     "cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@axelar-network/axelar-gmp-sdk-solidity": "^3.6.1"
   },
   "devDependencies": {
-    "@axelar-network/axelar-contract-deployments": "git://github.com/axelarnetwork/axelar-contract-deployments.git#4a5cd497d827672458bdfa1d7eb746eebb91cca2",
+    "@axelar-network/axelar-contract-deployments": "git://github.com/axelarnetwork/axelar-contract-deployments.git#74b942fdf10875a27b532d9bd6dfe2bd6db8a094",
     "@nomicfoundation/hardhat-toolbox": "^2.0.2",
     "chai": "^4.3.7",
     "cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@axelar-network/axelar-gmp-sdk-solidity": "^3.6.1"
   },
   "devDependencies": {
-    "@axelar-network/axelar-contract-deployments": "git://github.com/axelarnetwork/axelar-contract-deployments.git#68d0c9ee4b860f68045d8fe54f10c30f8aadc164",
+    "@axelar-network/axelar-contract-deployments": "git://github.com/axelarnetwork/axelar-contract-deployments.git#4a5cd497d827672458bdfa1d7eb746eebb91cca2",
     "@nomicfoundation/hardhat-toolbox": "^2.0.2",
     "chai": "^4.3.7",
     "cross-env": "^7.0.3",

--- a/test/AxelarGateway.js
+++ b/test/AxelarGateway.js
@@ -321,7 +321,9 @@ describe('AxelarGateway', () => {
             const params = getWeightedProxyDeployParams(notGovernance.address, mintLimiter.address, [], [], 1);
 
             await expect(
-                gateway.connect(governance).upgrade(newGatewayImplementation.address, newGatewayImplementationCodeHash, params, getGasOptions()),
+                gateway
+                    .connect(governance)
+                    .upgrade(newGatewayImplementation.address, newGatewayImplementationCodeHash, params, getGasOptions()),
             )
                 .to.emit(gateway, 'Upgraded')
                 .withArgs(newGatewayImplementation.address)

--- a/test/AxelarGateway.js
+++ b/test/AxelarGateway.js
@@ -6,6 +6,7 @@ const {
 } = ethers;
 const { expect } = chai;
 const { isHardhat, getChainId, getEVMVersion, getGasOptions, getRandomString } = require('./utils');
+const { getBytecodeHash } = require('@axelar-network/axelar-contract-deployments');
 
 const {
     bigNumberToNumber,
@@ -223,8 +224,7 @@ describe('AxelarGateway', () => {
 
         it('should allow the admins to upgrade to the correct implementation', async () => {
             const newGatewayImplementation = await gatewayFactory.deploy(auth.address, tokenDeployer.address).then((d) => d.deployed());
-            const newGatewayImplementationCode = await newGatewayImplementation.provider.getCode(newGatewayImplementation.address);
-            const newGatewayImplementationCodeHash = keccak256(newGatewayImplementationCode);
+            const newGatewayImplementationCodeHash = await getBytecodeHash(newGatewayImplementation);
 
             const newAdminAddresses = getAddresses(admins.slice(0, threshold - 1));
             const newOperatorAddresses = getAddresses(operators.slice(0, threshold - 1));


### PR DESCRIPTION
Codehash computation is different on polygon zkEVM, using poseidon hash function. Allow chain dependent bytecode hash retrieval.