### PR TITLE
chore: deps update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@axelar-network/axelar-cgp-solidity",
-  "version": "4.5.0",
+  "version": "5.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@axelar-network/axelar-cgp-solidity",
-      "version": "4.5.0",
+      "version": "5.0.0",
       "license": "ISC",
       "dependencies": {
-        "@axelar-network/axelar-gmp-sdk-solidity": "^3.6.1"
+        "@axelar-network/axelar-gmp-sdk-solidity": "^4.0.0"
       },
       "devDependencies": {
         "@axelar-network/axelar-contract-deployments": "git://github.com/axelarnetwork/axelar-contract-deployments.git#74b942fdf10875a27b532d9bd6dfe2bd6db8a094",
@@ -64,9 +64,9 @@
       }
     },
     "node_modules/@axelar-network/axelar-gmp-sdk-solidity": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@axelar-network/axelar-gmp-sdk-solidity/-/axelar-gmp-sdk-solidity-3.6.1.tgz",
-      "integrity": "sha512-jz8NSSbZpWUyE53JiXYp8cO8G32e7TB1u6tJiQtNKHsthajWxDZ4BcHZkjKMB2jVQJa4bjH2BbDq4BUb6aC90Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@axelar-network/axelar-gmp-sdk-solidity/-/axelar-gmp-sdk-solidity-4.0.0.tgz",
+      "integrity": "sha512-Qz3fF05xx0tN8Yf5aFkV4drqiFl/4qQ8gle/41gf3+YuJiSYZVH2JKbz1+9/ZkivLdU9/oj6CZoRg+2XzD5LdQ==",
       "engines": {
         "node": ">=16"
       }
@@ -11788,9 +11788,9 @@
       }
     },
     "@axelar-network/axelar-gmp-sdk-solidity": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@axelar-network/axelar-gmp-sdk-solidity/-/axelar-gmp-sdk-solidity-3.6.1.tgz",
-      "integrity": "sha512-jz8NSSbZpWUyE53JiXYp8cO8G32e7TB1u6tJiQtNKHsthajWxDZ4BcHZkjKMB2jVQJa4bjH2BbDq4BUb6aC90Q=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@axelar-network/axelar-gmp-sdk-solidity/-/axelar-gmp-sdk-solidity-4.0.0.tgz",
+      "integrity": "sha512-Qz3fF05xx0tN8Yf5aFkV4drqiFl/4qQ8gle/41gf3+YuJiSYZVH2JKbz1+9/ZkivLdU9/oj6CZoRg+2XzD5LdQ=="
     },
     "@babel/code-frame": {
       "version": "7.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelar-cgp-solidity",
-  "version": "4.5.0",
+  "version": "5.0.0",
   "description": "EVM Smart Contracts for Axelar Network",
   "main": "index.js",
   "scripts": {
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/axelarnetwork/axelar-cgp-solidity#readme",
   "dependencies": {
-    "@axelar-network/axelar-gmp-sdk-solidity": "^3.6.1"
+    "@axelar-network/axelar-gmp-sdk-solidity": "^4.0.0"
   },
   "devDependencies": {
     "@axelar-network/axelar-contract-deployments": "git://github.com/axelarnetwork/axelar-contract-deployments.git#74b942fdf10875a27b532d9bd6dfe2bd6db8a094",

--- a/test/AxelarGateway.js
+++ b/test/AxelarGateway.js
@@ -134,9 +134,9 @@ describe('AxelarGateway', () => {
             const implementationBytecodeHash = keccak256(implementationBytecode);
 
             const expected = {
-                istanbul: '0x9ea40c1a3b70ab5ec544656ec8a8e13ff615f1ea781553466a38370c30bebf2c',
-                berlin: '0x268a9beb6a183ffa92764c4488a8b49028c4bfaf59ee2508315b1154340678ba',
-                london: '0x977572811dff54b28d5ec38827fdf49335f0dce0c628edb39223e99396981491',
+                istanbul: '0x23245e7226b99ddcdd733b18024488e6de2ed7f8252bdccf9a7e3d11ee5fd880',
+                berlin: '0x76925c080386102f9b231d744e7632373bcf55eb0278886ba7dcf5c0cc482a5e',
+                london: '0x21c30afa0f635e1825624afa415dc8f166172138b0ab7160c389d82fba363cb6',
             }[getEVMVersion()];
 
             expect(implementationBytecodeHash).to.be.equal(expected);

--- a/test/AxelarGateway.js
+++ b/test/AxelarGateway.js
@@ -133,8 +133,6 @@ describe('AxelarGateway', () => {
             const implementationBytecode = gatewayFactory.bytecode;
             const implementationBytecodeHash = keccak256(implementationBytecode);
 
-            console.log(implementationBytecodeHash);
-
             const expected = {
                 istanbul: '0x9ea40c1a3b70ab5ec544656ec8a8e13ff615f1ea781553466a38370c30bebf2c',
                 berlin: '0x268a9beb6a183ffa92764c4488a8b49028c4bfaf59ee2508315b1154340678ba',


### PR DESCRIPTION
Updating the GMP SDK to `v4.0.0`