### PR TITLE
chore: ignore erc20 files for lint errors

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -5,6 +5,8 @@
     "quotes": ["error", "single"],
     "compiler-version": ["off"],
     "func-visibility": ["warn", { "ignoreConstructors": true }],
+    "func-name-mixedcase": "error",
+    "var-name-mixedcase": "error",
     "no-inline-assembly": "off",
     "no-empty-blocks": "off",
     "avoid-low-level-calls": "off",

--- a/.solhintignore
+++ b/.solhintignore
@@ -1,0 +1,3 @@
+node_modules
+contracts/ERC20Permit.sol
+contracts/interfaces/IERC20Permit.sol


### PR DESCRIPTION
ERC20 files have a fixed bytecode. Ignore lint errors for them