### PR TITLE
fix(gitignore): interfaces relative path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,7 +109,7 @@ dist
 build/
 cache/
 artifacts/
-interfaces/
+/interfaces
 
 info/local.json
 keys.json


### PR DESCRIPTION
PR to fix interfaces relative path in .gitignore so it no longer overshadows contracts/interfaces