### PR TITLE
refactor: tests for axelar auth weighted to reduce signers required [AXE-2323]

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ await sourceChainGateway
 
 - Make sure that the account being used to broadcast transactions has enough native balance. The maximum `gasLimit` for a chain should be fetched from an explorer and set it in config file. You may also need to update the `confirmations` required for a transaction to be successfully included in a block in the config [here](https://github.com/axelarnetwork/axelar-contract-deployments/tree/main/axelar-chains-config/info) depending on the network.
 
-- For `AxelarAuthWeighted.js` tests to pass provide 16 different accounts in `keys.json` as value of `OLD_KEY_RETENTION` is 16.
+- For `AxelarAuthWeighted.js` tests to pass provide 3 different accounts in `keys.json` for creating different sets of operators.
 
 - Transactions can fail if previous transactions are not mined and picked up by the provide, therefore wait for a transaction to be mined after broadcasting. See the code below for example
 ```javascript

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ await sourceChainGateway
 
 - Make sure that the account being used to broadcast transactions has enough native balance. The maximum `gasLimit` for a chain should be fetched from an explorer and set it in config file. You may also need to update the `confirmations` required for a transaction to be successfully included in a block in the config [here](https://github.com/axelarnetwork/axelar-contract-deployments/tree/main/axelar-chains-config/info) depending on the network.
 
-- For `AxelarAuthWeighted.js` tests to pass provide 3 different accounts in `keys.json` for creating different sets of operators.
+- Note that certain tests can require upto 3 accounts.
 
 - Transactions can fail if previous transactions are not mined and picked up by the provide, therefore wait for a transaction to be mined after broadcasting. See the code below for example
 ```javascript

--- a/test/auth/AxelarAuthWeighted.js
+++ b/test/auth/AxelarAuthWeighted.js
@@ -35,14 +35,8 @@ describe('AxelarAuthWeighted', () => {
         operators = sortBy(wallets.slice(1, 3), (wallet) => wallet.address.toLowerCase());
         let previousOperatorsLimit = OLD_KEY_RETENTION;
 
-        for (let i = 0; i < wallets.length - 2; i++) {
-            for (let j = i; j < wallets.length - 2; j++) {
-                previousOperators.push(sortBy(wallets.slice(i, j + 2), (wallet) => wallet.address.toLowerCase()));
-                --previousOperatorsLimit;
-            }
-
-            if (previousOperatorsLimit <= 0) break;
-        }
+        previousOperators.push(sortBy(wallets.slice(0, 2), (wallet) => wallet.address.toLowerCase()));
+        --previousOperatorsLimit;
 
         authFactory = await ethers.getContractFactory('AxelarAuthWeighted', owner);
     });

--- a/test/auth/AxelarAuthWeighted.js
+++ b/test/auth/AxelarAuthWeighted.js
@@ -6,7 +6,7 @@ const {
 } = ethers;
 const { expect } = chai;
 
-const OLD_KEY_RETENTION = 16;
+const OLD_KEY_RETENTION = 3;
 
 const {
     getAddresses,
@@ -17,7 +17,7 @@ const {
 } = require('../utils');
 
 describe('AxelarAuthWeighted', () => {
-    const threshold = 3;
+    const threshold = 2;
 
     let wallets;
     let owner;
@@ -32,13 +32,12 @@ describe('AxelarAuthWeighted', () => {
         wallets = await ethers.getSigners();
 
         owner = wallets[0];
-        operators = sortBy(wallets.slice(3, 9), (wallet) => wallet.address.toLowerCase());
-
+        operators = sortBy(wallets.slice(1, 3), (wallet) => wallet.address.toLowerCase());
         let previousOperatorsLimit = OLD_KEY_RETENTION;
 
-        for (let i = 0; i < wallets.length - 3; i++) {
-            for (let j = i; j < wallets.length - 3; j++) {
-                previousOperators.push(sortBy(wallets.slice(i, j + 3), (wallet) => wallet.address.toLowerCase()));
+        for (let i = 0; i < wallets.length - 2; i++) {
+            for (let j = i; j < wallets.length - 2; j++) {
+                previousOperators.push(sortBy(wallets.slice(i, j + 2), (wallet) => wallet.address.toLowerCase()));
                 --previousOperatorsLimit;
             }
 
@@ -153,61 +152,6 @@ describe('AxelarAuthWeighted', () => {
             );
         });
 
-        it('validate the proof from the recent operators', async () => {
-            const data = '0x123abc123abc';
-
-            const message = hashMessage(arrayify(keccak256(data)));
-
-            const validPreviousOperators = previousOperators.slice(-(OLD_KEY_RETENTION - 1));
-
-            await expect(validPreviousOperators.length).to.be.equal(OLD_KEY_RETENTION - 1);
-
-            await Promise.all(
-                validPreviousOperators.map(async (operators) => {
-                    const isCurrentOperators = await auth.validateProof(
-                        message,
-                        getWeightedSignaturesProof(
-                            data,
-                            operators,
-                            operators.map(() => 1),
-                            threshold,
-                            operators.slice(0, threshold),
-                        ),
-                    );
-                    await expect(isCurrentOperators).to.be.equal(false);
-                }),
-            );
-        });
-
-        it('reject the proof from the operators older than key retention', async () => {
-            const data = '0x123abc123abc';
-
-            const message = hashMessage(arrayify(keccak256(data)));
-
-            const invalidPreviousOperators = previousOperators.slice(0, -(OLD_KEY_RETENTION - 1));
-
-            await Promise.all(
-                invalidPreviousOperators.map(async (operators) => {
-                    await expectRevert(
-                        (gasOptions) =>
-                            auth.validateProof(
-                                message,
-                                getWeightedSignaturesProof(
-                                    data,
-                                    operators,
-                                    operators.map(() => 1),
-                                    threshold,
-                                    operators.slice(0, threshold),
-                                ),
-                                gasOptions,
-                            ),
-                        auth,
-                        'InvalidOperators',
-                    );
-                }),
-            );
-        });
-
         it('validate the proof for a single operator', async () => {
             const signleOperator = getAddresses([owner]);
 
@@ -257,6 +201,81 @@ describe('AxelarAuthWeighted', () => {
             );
 
             await expect(isCurrentOperators).to.be.equal(true);
+        });
+    });
+
+    describe('validateProof with OLD_KEY_RETENTION as 16', () => {
+        const OLD_KEY_RETENTION = 16;
+        let newAuth;
+        const previousOperators = [];
+        before(async () => {
+            for (let i = 0; i < OLD_KEY_RETENTION; i++) {
+                previousOperators.push(sortBy(wallets.slice(0, 2), (wallet) => wallet.address.toLowerCase()));
+            }
+
+            const initialOperators = [...previousOperators, operators];
+            newAuth = await authFactory
+                .deploy(
+                    getWeightedAuthDeployParam(
+                        initialOperators.map(getAddresses),
+                        initialOperators.map(({ length }, index) => Array(length).fill(index + 1)), // weights
+                        initialOperators.map(() => threshold),
+                    ),
+                )
+                .then((d) => d.deployed());
+        });
+
+        it('validate the proof from the recent operators', async () => {
+            const data = '0x123abc123abc';
+
+            const message = hashMessage(arrayify(keccak256(data)));
+
+            const validPreviousOperators = previousOperators.slice(-(OLD_KEY_RETENTION - 1));
+
+            expect(validPreviousOperators.length).to.be.equal(OLD_KEY_RETENTION - 1);
+
+            await Promise.all(
+                validPreviousOperators.map(async (operators, index) => {
+                    const isCurrentOperators = await newAuth.validateProof(
+                        message,
+                        getWeightedSignaturesProof(
+                            data,
+                            operators,
+                            operators.map(() => index + 2),
+                            threshold,
+                            operators.slice(0, threshold),
+                        ),
+                    );
+                    expect(isCurrentOperators).to.be.equal(false);
+                }),
+            );
+        });
+
+        it('reject the proof from the operators older than key retention', async () => {
+            const data = '0x123abc123abc';
+            const message = hashMessage(arrayify(keccak256(data)));
+            const invalidPreviousOperators = previousOperators.slice(0, -(OLD_KEY_RETENTION - 1));
+
+            await Promise.all(
+                invalidPreviousOperators.map(async (operators) => {
+                    await expectRevert(
+                        (gasOptions) =>
+                            newAuth.validateProof(
+                                message,
+                                getWeightedSignaturesProof(
+                                    data,
+                                    operators,
+                                    operators.map(() => 1),
+                                    threshold,
+                                    operators.slice(0, threshold),
+                                ),
+                                gasOptions,
+                            ),
+                        auth,
+                        'InvalidOperators',
+                    );
+                }),
+            );
         });
     });
 
@@ -332,7 +351,7 @@ describe('AxelarAuthWeighted', () => {
                 auth.transferOperatorship(
                     getTransferWeightedOperatorshipCommand(
                         updatedOperators,
-                        updatedOperators.map(() => 1),
+                        updatedOperators.map(() => 2),
                         threshold,
                     ),
                 ),
@@ -340,7 +359,7 @@ describe('AxelarAuthWeighted', () => {
                 .to.emit(auth, 'OperatorshipTransferred')
                 .withArgs(
                     updatedOperators,
-                    updatedOperators.map(() => 1),
+                    updatedOperators.map(() => 2),
                     threshold,
                 );
 

--- a/test/auth/AxelarAuthWeighted.js
+++ b/test/auth/AxelarAuthWeighted.js
@@ -1,6 +1,6 @@
 const { sortBy } = require('lodash');
 const chai = require('chai');
-const { ethers } = require('hardhat');
+const { ethers, network } = require('hardhat');
 const {
     utils: { arrayify, defaultAbiCoder, keccak256, hashMessage },
 } = ethers;
@@ -50,15 +50,14 @@ describe('AxelarAuthWeighted', () => {
     beforeEach(async () => {
         const initialOperators = [...previousOperators, operators];
 
-        auth = await authFactory
-            .deploy(
-                getWeightedAuthDeployParam(
-                    initialOperators.map(getAddresses),
-                    initialOperators.map(({ length }) => Array(length).fill(1)), // weights
-                    initialOperators.map(() => threshold),
-                ),
-            )
-            .then((d) => d.deployed());
+        auth = await authFactory.deploy(
+            getWeightedAuthDeployParam(
+                initialOperators.map(getAddresses),
+                initialOperators.map(({ length }) => Array(length).fill(1)), // weights
+                initialOperators.map(() => threshold),
+            ),
+        );
+        await auth.deployTransaction.wait(network.config.confirmations);
     });
 
     describe('validateProof', () => {
@@ -214,15 +213,14 @@ describe('AxelarAuthWeighted', () => {
             }
 
             const initialOperators = [...previousOperators, operators];
-            newAuth = await authFactory
-                .deploy(
-                    getWeightedAuthDeployParam(
-                        initialOperators.map(getAddresses),
-                        initialOperators.map(({ length }, index) => Array(length).fill(index + 1)), // weights
-                        initialOperators.map(() => threshold),
-                    ),
-                )
-                .then((d) => d.deployed());
+            newAuth = await authFactory.deploy(
+                getWeightedAuthDeployParam(
+                    initialOperators.map(getAddresses),
+                    initialOperators.map(({ length }, index) => Array(length).fill(index + 1)), // weights
+                    initialOperators.map(() => threshold),
+                ),
+            );
+            await newAuth.deployTransaction.wait(network.config.confirmations);
         });
 
         it('validate the proof from the recent operators', async () => {

--- a/test/auth/AxelarAuthWeighted.js
+++ b/test/auth/AxelarAuthWeighted.js
@@ -6,8 +6,6 @@ const {
 } = ethers;
 const { expect } = chai;
 
-const OLD_KEY_RETENTION = 3;
-
 const {
     getAddresses,
     getWeightedAuthDeployParam,
@@ -33,10 +31,7 @@ describe('AxelarAuthWeighted', () => {
 
         owner = wallets[0];
         operators = sortBy(wallets.slice(1, 3), (wallet) => wallet.address.toLowerCase());
-        let previousOperatorsLimit = OLD_KEY_RETENTION;
-
         previousOperators.push(sortBy(wallets.slice(0, 2), (wallet) => wallet.address.toLowerCase()));
-        --previousOperatorsLimit;
 
         authFactory = await ethers.getContractFactory('AxelarAuthWeighted', owner);
     });


### PR DESCRIPTION
Refactored the tests to reduce the number of signers required to 3 for live network testing