### PR TITLE
Remove engine requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,7 @@
     "type": "git",
     "url": "git+https://github.com/axelarnetwork/axelar-cgp-solidity.git"
   },
-  "keywords": [
-    "ethereum",
-    "axelar"
-  ],
+  "keywords": ["ethereum", "axelar"],
   "author": "axelar-network",
   "license": "MIT",
   "bugs": {
@@ -53,15 +50,5 @@
     "readline-sync": "^1.4.10",
     "solhint": "^4.5.2"
   },
-  "engines": {
-    "node": ">=18"
-  },
-  "files": [
-    "artifacts",
-    "contracts",
-    "interfaces",
-    "scripts",
-    "README.md",
-    "hardhat.config.js"
-  ]
+  "files": ["artifacts", "contracts", "interfaces", "scripts", "README.md", "hardhat.config.js"]
 }


### PR DESCRIPTION
We use this package via our import of `@axelar-network/axelarjs-sdk` in `@osmosis-labs/web` package of our [frontend](https://github.com/osmosis-labs/osmosis-frontend) monorepo.

We have recently moved to Node.js v20, and the engine requirement in this package prevents us from updating packages.

Using Node.js `v20.11.1` with this package, I was able to use npm to install dependencies, build and test with no issues.

Once this is merged and published, I'll make sure to open a PR in `@axelar-network/axelarjs-sdk` to include this update. Then, we can import it into our frontend.

Thank you!