### PR TITLE
chore(test): add case for validating parent hash

### DIFF
--- a/test/RpcCompatibility.js
+++ b/test/RpcCompatibility.js
@@ -133,6 +133,7 @@ describe('RpcCompatibility', () => {
                     finalizedBlockNumber = await provider.send('eth_getBlockByNumber', ['finalized', false]);
                 } catch (error) {
                     console.error('Failed to retrieve finalized block number:', error);
+                    throw error;
                 }
             });
 

--- a/test/RpcCompatibility.js
+++ b/test/RpcCompatibility.js
@@ -263,7 +263,7 @@ describe('RpcCompatibility', () => {
         });
 
         it('should have valid parent hashes', async () => {
-            validParentHashes('latest')
+            validParentHashes('latest');
         });
     });
 

--- a/test/RpcCompatibility.js
+++ b/test/RpcCompatibility.js
@@ -264,6 +264,7 @@ describe('RpcCompatibility', () => {
         });
 
         it('should have valid parent hashes', async () => {
+            // Note: If chain doesn't have instant finality, reorgs could cause this to fail
             validParentHashes('latest');
         });
     });

--- a/test/RpcCompatibility.js
+++ b/test/RpcCompatibility.js
@@ -39,9 +39,9 @@ describe('RpcCompatibility', () => {
         expect(timeDifference).to.be.lessThanOrEqual(maxDifference);
     }
 
-    async function validParentHashes(tag) {
+    async function validParentHashes(blockTag) {
         const withTransaction = false;
-        const block = await provider.send('eth_getBlockByNumber', ['latest', withTransaction]);
+        const block = await provider.send('eth_getBlockByNumber', [blockTag, withTransaction]);
         const parentBlock = await provider.send('eth_getBlockByHash', [block.parentHash, withTransaction]);
 
         expect(parentBlock.hash).to.equal(block.parentHash);

--- a/test/RpcCompatibility.js
+++ b/test/RpcCompatibility.js
@@ -243,6 +243,19 @@ describe('RpcCompatibility', () => {
             checkBlock(block, false);
             checkBlockTimeStamp(parseInt(block.timestamp, 16), 12000);
         });
+
+        it('blocks have valid parent hashes', async () => {
+            const withTransaction = false;
+            const block = await provider.send('eth_getBlockByNumber', ['latest', withTransaction]);
+            const parentBlock = await provider.send('eth_getBlockByHash', [block.parentHash, withTransaction]);
+
+            console.log('Block:', block);
+            console.log('Parent block:', parentBlock);
+
+            checkBlock(parentBlock, withTransaction);
+
+            expect(parentBlock.hash).to.equal(block.parentHash);
+        });
     });
 
     it('should support RPC method eth_blockNumber', async () => {


### PR DESCRIPTION
Add tests to validate block parent hashes. In the light of Flow behaviour explained as per [this](https://interoplabs.slack.com/archives/C021B409SG5/p1724405403164199?thread_ts=1724405178.231209&cid=C021B409SG5) thread.