### PR TITLE
[DO NOT MERGE] test berachain compatability

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -12,7 +12,8 @@ if (process.env.CHECK_CONTRACT_SIZE) {
 const { importNetworks, readJSON } = require('@axelar-network/axelar-chains-config');
 
 const env = process.env.ENV || 'testnet';
-const chains = require(`@axelar-network/axelar-chains-config/info/${env}.json`);
+//const chains = require(`@axelar-network/axelar-chains-config/info/${env}.json`);
+const chains = require(`../axelar-contract-deployments/axelar-chains-config/info/${env}.json`);
 const keys = readJSON(`${__dirname}/keys.json`);
 const { networks, etherscan } = importNetworks(chains, keys);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "6.4.0",
       "license": "MIT",
       "dependencies": {
+        "@axelar-network/axelar-cgp-solidity": "^6.4.0",
         "@axelar-network/axelar-gmp-sdk-solidity": "5.10.0"
       },
       "devDependencies": {
@@ -61,6 +62,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@axelar-network/axelar-cgp-solidity": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@axelar-network/axelar-cgp-solidity/-/axelar-cgp-solidity-6.4.0.tgz",
+      "integrity": "sha512-Xnw5xi234B1cmTCzgudV8zq+DDjJ1d1U362CM0vKH1FWmZprKIdqgmOYkiRyu+QiVhnznKiBURiSEHVrNjtYpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@axelar-network/axelar-gmp-sdk-solidity": "5.10.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@axelar-network/axelar-chains-config": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "homepage": "https://github.com/axelarnetwork/axelar-cgp-solidity#readme",
   "dependencies": {
+    "@axelar-network/axelar-cgp-solidity": "^6.4.0",
     "@axelar-network/axelar-gmp-sdk-solidity": "5.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
isaacmarkus@Mac axelar-cgp-solidity % npx hardhat test --network berachain                


  AxelarDepositService
    deposit service
      ✔ should revert on deployment if gateway is invalid (271ms)
      ✔ should revert on deployment if token is invalid (237ms)
      ✔ should revert on deployment if refund issuer is invalid (418ms)
      ✔ should return the correct token symbol (364ms)
      ✔ should revert on send native token if value is zero (163ms)
sendNative gas: 107854
      ✔ should send native token (9305ms)
sendTokenDeposit gas: 123978
      ✔ should handle and transfer ERC20 token (10884ms)
      1) should refund from transfer token address
      2) should refund from transfer token address to msg.sender if refund address is the zero address
sendNativeDeposit gas: 134395
      ✔ should wrap and transfer native currency (10556ms)
      ✔ should refund from transfer native address (23156ms)
      3) should unwrap native currency
      4) should refund from unwrap native address
      5) should refund to the service when refundAddress is 0x0
    should preserve the bytecode [ @skip-on-coverage ]
      ✔ should have the same receiver bytecode preserved for each EVM
      ✔ should have the same proxy bytecode preserved for each EVM

  AxelarGateway
    axelar gateway proxy
      ✔ should revert on invalid gateway implementation address (157ms)
      ✔ should revert if gateway setup fails (14522ms)
      ✔ should fail on receiving native value (24802ms)
    constructor checks
      ✔ should revert if auth module is not a contract (190ms)
      ✔ should revert if token deployer is not a contract (239ms)
      ✔ check internal constants (9123ms)
    deployment params
      ✔ should get the correct governance address (219ms)
      ✔ should get the correct mint limiter address (150ms)
      ✔ should get the correct auth module (152ms)
      ✔ auth module should have the correct owner (156ms)
      ✔ should get the correct token deployer (229ms)
    check external methods that should only be called by self
      ✔ should fail on external call to deployToken (173ms)
      ✔ should fail on external call to mintToken (179ms)
      ✔ should fail on external call to burnToken (189ms)
      ✔ should fail on external call to approveContractCall (163ms)
      ✔ should fail on external call to approveContractCallWithMint (184ms)
      ✔ should fail on external call to transferOperatorship (154ms)
    should preserve the bytecode [ @skip-on-coverage ]
      ✔ should preserve the same proxy bytecode for each EVM
      ✔ should preserve the implementation bytecode for each EVM
      ✔ should have the same deposit handler bytecode preserved for each EVM
      ✔ should have the same token bytecode preserved for each EVM
    setTokenMintLimits
      ✔ should allow governance to set a token's daily limit (5668ms)
    gateway operators
      ✔ should allow transferring governance (5797ms)
      ✔ should allow transferring mint limiter (10350ms)
    upgrade
      ✔ should allow governance to upgrade to the correct implementation (15153ms)
      ✔ should allow governance to upgrade to the correct implementation with new governance and mint limiter (10547ms)
      ✔ should allow governance to upgrade to the correct implementation with new operators (11032ms)
      ✔ should allow governance to upgrade to the correct implementation with new governance and operators (10482ms)
      ✔ should allow governance to upgrade to the same implementation with new governance (6431ms)
      ✔ should not allow governance to upgrade to a wrong implementation (11342ms)
      ✔ should not allow calling the setup function directly (5354ms)
      ✔ should not allow malicious proxy to call setup function directly and transfer governance or mint limiter (5626ms)
      ✔ should not allow calling the upgrade on the implementation (9560ms)
      ✔ should revert on upgrade if setup fails for any reason (9280ms)
    chain id
      ✔ should fail if chain id mismatches (243ms)
    command deployToken
deployToken gas: 1318967
      ✔ should allow operators to deploy a new token (5743ms)
      ✔ should not deploy a duplicate token (10269ms)
    command mintToken
      ✔ should not allow the operators to mint tokens exceeding the daily limit (18943ms)
      ✔ should allow the operators to mint tokens (5312ms)
      ✔ should not mint wrong symbols (5267ms)
    command burnToken
      burn token positive tests
burnToken internal gas: 111475
        ✔ should allow the operators to burn internal tokens (24243ms)
burnToken external gas: 355091
        ✔ should allow the operators to burn external tokens (20145ms)
        ✔ should allow the operators to burn external tokens even if the deposit address has ether (32978ms)
        ✔ should allow the operators to burn the external token multiple times from the same address (25017ms)
      burn token negative tests
        ✔ should fail if symbol does not correspond to internal token (9977ms)
        ✔ should fail to burn external tokens if deposit handler execute reverts (4869ms)
        ✔ should fail to burn external tokens if deposit handler execute fails (9879ms)
    command transferOperatorship
transferOperatorship gas: 153029
      ✔ should allow operators to transfer operatorship (5031ms)
      ✔ should not allow transferring operatorship to address zero (4907ms)
      ✔ should allow the previous operators to mint and burn token (29268ms)
      ✔ should not allow the previous operators to transfer operatorship (9773ms)
      ✔ should not allow operatorship transfer to the previous operators (13883ms)
      ✔ should not allow multiple operatorship transfers in one batch (4864ms)
    sendToken
      send token negative tests
        ✔ should fail if token deployment fails (5047ms)
      send token positive tests
sendToken internal gas: 60518
        ✔ should burn internal token and emit an event (15330ms)
sendNative external gas: 76125
        ✔ should lock external token and emit an event (19963ms)
    external tokens
      ✔ should fail if external ERC20 token address is invalid (5031ms)
      ✔ should support external ERC20 token (24222ms)
    batch commands
      ✔ should revert on mismatch between commandID and command/params length (510ms)
      ✔ should batch execute multiple commands and skip any unknown commands (13143ms)
      ✔ should not execute the same commandID twice (5029ms)
    callContract
callContract gas: 34582
      ✔ should emit an event (5270ms)
    callContractWithToken
      ✔ should revert if token does not exist (141ms)
      ✔ should revert if token amount is invalid (139ms)
callContractWithToken internal gas: 63567
      ✔ should burn internal token and emit an event (19512ms)
callContractWithToken external gas: 79223
      ✔ should lock external token and emit an event (20293ms)
    external contract approval and execution
      ✔ should approve and validate contract call (15466ms)
      ✔ should approve and validate contract call with token (25341ms)
    deprecated functions
      ✔ should return correct value for allTokensFrozen (164ms)
      ✔ should return correct value for tokenFrozen (160ms)

  AxelarGatewayUpgrade
    ✔ should deploy gateway with the correct modules (834ms)
    ✔ should upgrade AxelarGateway through InterchainGovernance proposal (33240ms)

  BurnableMintableCappedERC20
    Owner operations
      ✔ should revert on transfer ownership if called by non-owner (375ms)
      ✔ should revert on transfer ownership if new owner is invalid (372ms)
      ✔ should transfer ownership (5581ms)
    ERC20 Basics
      ✔ should increase and decrease allowance (10662ms)
      ✔ should revert on approve with invalid owner or sender (588ms)
      ✔ should transfer with max possible allowance (14504ms)
      ✔ should revert on transfer to invalid address (5593ms)
    ERC20 Permit
      ✔ should should set allowance by verifying permit (10200ms)
      ✔ should revert if permit is expired (418ms)
      ✔ should revert if signature is incorrect (1154ms)
    ERC20 Mint
      ✔ should allow owner to mint (5080ms)
      ✔ should revert if non-owner mints (355ms)
      ✔ should revert if total supply is greater than capacity (294ms)
      ✔ should revert if account is invalid (325ms)
    ERC20 Burn
      ✔ should revert when non-owner calls either burn function (620ms)
      ✔ should revert on burn with an invalid address (158ms)
      ✔ should allow owner to burn (11310ms)

  DepositHandler
    execute
      ✔ should execute function call on another contract (9297ms)
      ✔ should revert if callee is not a contract (241ms)
      ✔ should revert if locked (no reentrancy) (5059ms)
    destroy
      6) should destroy the contract and send ETH to destination
      7) should revert if locked (no reentrancy)

  ECDSA
    recover with invalid signature
      ✔ with short signature (159ms)
      ✔ with long signature (161ms)
    recover with valid signature
      ✔ returns signer address with correct signature (251ms)
      ✔ returns signer address with correct signature for arbitrary length message (177ms)
      ✔ returns a different address (172ms)
      ✔ reverts with invalid signature (158ms)
    with v=27 signature
      ✔ works with correct v value (207ms)
      ✔ rejects incorrect v value (219ms)
      ✔ reverts wrong v values (1036ms)
    with v=28 signature
      ✔ works with correct v value (168ms)
      ✔ rejects incorrect v value (262ms)
      ✔ reverts invalid v values (369ms)
      ✔ reverts with high-s value signature (184ms)
    compute Ethereum Signed Message Hash
      ✔ should correctly compute the Ethereum Signed Message Hash (171ms)

  EternalStorage
    ✔ should store, get, and delete uint values (14680ms)
    ✔ should store, get, and delete string values (10703ms)
    ✔ should store, get, and delete address values (14659ms)
    ✔ should store, get, and delete bytes values (14770ms)
    ✔ should store, get, and delete bool values (10847ms)
    ✔ should store, get, and delete int values (11113ms)

  Proxy
    ✔ should revert if non-owner calls init (458ms)
    ✔ should revert if proxy is already initialized (5559ms)
    ✔ should revert if setup fails (222ms)
    ✔ should revert with invalid contract ID (5476ms)
    ✔ should revert if native value is sent to the proxy (183ms)
    8) should be a no-op if setup is called

  RpcCompatibility
    ✔ should support RPC method eth_blockNumber (124ms)
    ✔ should support RPC method eth_call (5633ms)
    ✔ should support RPC method eth_getCode (103ms)
    ✔ should support RPC method eth_gasPrice (100ms)
    ✔ should support RPC method eth_chainId (97ms)
    ✔ should support RPC method eth_getTransactionCount (5548ms)
    ✔ should support RPC method eth_sendRawTransaction [ @skip-on-coverage ] (5107ms)
    ✔ should support RPC method eth_getBalance (92ms)
    ✔ should support RPC method eth_syncing (112ms)
    ✔ should support RPC method eth_subscribe (9335ms)
    ✔ should return consistent logIndex values between eth_getLogs and eth_getTransactionReceipt (7136ms)
    eth_getLogs
      ✔ should support RPC method eth_getLogs (252ms)
      9) supports safe tag
      ✔ should have valid parent hash
      supports finalized tag
        ✔ should return latest.number > finalized.number (116ms)
    rpc get transaction and blockByHash methods
      ✔ should support RPC method eth_getTransactionReceipt (82ms)
      ✔ should support RPC method eth_getTransactionByHash (110ms)
      ✔ should support RPC method eth_getBlockByHash (236ms)
    eth_getBlockByNumber
      ✔ should support RPC method eth_getBlockByNumber (649ms)
      ✔ supports safe tag (220ms)
      ✔ supports finalized tag (259ms)
      ✔ should have valid parent hashes
    eth_estimateGas
      ✔ should support RPC method eth_estimateGas like ethereum mainnet (126ms)
      ✔ should send tx with estimated gas (6280ms)
    eip-1559 supported rpc methods
      ✔ should support RPC method eth_maxPriorityFeePerGas (3970ms)
      ✔ should send transaction based on RPC method eth_feeHistory pricing (3982ms)

  AxelarAuthWeighted
    validateProof
      10) "before each" hook for "validate the proof from the current operators"

  AxelarGasService
    AxelarGasService
      11) should emit events when receives gas payment
      12) should allow to collect accumulated payments and refund
      13) should allow to collect accumulated payments and refund with the new method
      ✔ should upgrade the gas receiver implementation (24066ms)
      14) should emit events when gas is added
      15) should emit events when gas is added for express calls
      ✔ should preserve the bytecode [ @skip-on-coverage ]
      Gas Estimation
        ✔ should allow the collector to update gas info (8501ms)
        ✔ should allow paying gas without on-chain gas estimation using payGas (7379ms)
        ✔ should allow paying gas with on-chain estimation (7969ms)

  GeneralMessagePassing
    general message passing
      16) "before each" hook for "should swap tokens on remote chain"


  158 passing (47m)
  16 failing

  1) AxelarDepositService
       deposit service
         should refund from transfer token address:
     Error: Multiple transactions found in block
      at ensure (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/calledOnContract/utils.ts:13:11)
      at getBalanceChange (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/changeEtherBalance.ts:78:9)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async Promise.all (index 0)
      at Context.<anonymous> (test/AxelarDepositService.js:274:13)

  2) AxelarDepositService
       deposit service
         should refund from transfer token address to msg.sender if refund address is the zero address:
     Error: Multiple transactions found in block
      at ensure (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/calledOnContract/utils.ts:13:11)
      at getBalanceChange (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/changeEtherBalance.ts:78:9)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async Promise.all (index 0)
      at Context.<anonymous> (test/AxelarDepositService.js:320:13)

  3) AxelarDepositService
       deposit service
         should unwrap native currency:
     Error: Multiple transactions found in block
      at ensure (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/calledOnContract/utils.ts:13:11)
      at getBalanceChange (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/changeEtherBalance.ts:78:9)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async Promise.all (index 0)
      at Context.<anonymous> (test/AxelarDepositService.js:421:13)

  4) AxelarDepositService
       deposit service
         should refund from unwrap native address:
     Error: Multiple transactions found in block
      at ensure (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/calledOnContract/utils.ts:13:11)
      at getBalanceChange (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/changeEtherBalance.ts:78:9)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async Promise.all (index 0)
      at Context.<anonymous> (test/AxelarDepositService.js:453:13)

  5) AxelarDepositService
       deposit service
         should refund to the service when refundAddress is 0x0:
     Error: Multiple transactions found in block
      at ensure (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/calledOnContract/utils.ts:13:11)
      at getBalanceChange (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/changeEtherBalance.ts:78:9)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async Promise.all (index 0)
      at Context.<anonymous> (test/AxelarDepositService.js:481:13)

  6) DepositHandler
       destroy
         should destroy the contract and send ETH to destination:
     Error: Multiple transactions found in block
      at ensure (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/calledOnContract/utils.ts:13:11)
      at getBalanceChange (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/changeEtherBalance.ts:78:9)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async Promise.all (index 0)
      at Context.<anonymous> (test/DepositHandler.js:52:13)

  7) DepositHandler
       destroy
         should revert if locked (no reentrancy):
     Error: Multiple transactions found in block
      at ensure (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/calledOnContract/utils.ts:13:11)
      at getBalanceChange (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/changeEtherBalance.ts:78:9)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async Promise.all (index 0)
      at Context.<anonymous> (test/DepositHandler.js:65:13)

  8) Proxy
       should be a no-op if setup is called:
     TypeError: Cannot read properties of null (reading 'status')
      at onSuccess (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/reverted/reverted.ts:31:19)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at Context.<anonymous> (test/Proxy.js:96:9)

  9) RpcCompatibility
       eth_getLogs
         supports safe tag:
     ProviderError: invalid params
      at HttpProvider.request (/Users/isaacmarkus/axelar-cgp-solidity/node_modules/hardhat/src/internal/core/providers/http.ts:90:21)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at EthersProviderWrapper.send (/Users/isaacmarkus/axelar-cgp-solidity/node_modules/@nomiclabs/hardhat-ethers/src/internal/ethers-provider-wrapper.ts:13:20)
      at checkLog (/Users/isaacmarkus/axelar-cgp-solidity/test/RpcCompatibility.js:66:25)
      at Context.<anonymous> (/Users/isaacmarkus/axelar-cgp-solidity/test/RpcCompatibility.js:125:13)

  10) AxelarAuthWeighted
       "before each" hook for "validate the proof from the current operators":
     Error: cannot estimate gas; transaction may fail or may require manual gas limit [ See: https://links.ethers.org/v5-errors-UNPREDICTABLE_GAS_LIMIT ] (reason="execution reverted", method="estimateGas", transaction={"from":"0xc84f53Eb743E45204a7e3756B984368C25A68a1b","data":"0x60806040523480156200001157600080fd5b50604051620018d1380380620018d1833981016040819052620000349162000418565b33620000408162000098565b50805160005b818110156200008f576200007c83828151811062000068576200006862000556565b60200260200101516200013c60201b60201c565b620000878162000582565b905062000046565b505050620007a0565b6001600160a01b038116620000c057604051633649397d60e21b815260040160405180910390fd5b6040516001600160a01b038216907f04dba622d284ed0014ee4b9a6a68386be1a4c08a4913ae272de89199cc68616390600090a27f02016836a56b71f0d02689e69e326f4f4c1b9057164ef592671cf0d37c8040c05560007f9855384122b55936fbfb8ca5120e63c6537a1ac40caf6ae33502b3c5da8c87d155565b6000806000838060200190518101906200015791906200060d565b825182519396509194509250908115806200017a57506200017885620002ee565b155b156200019957604051630849699d60e11b815260040160405180910390fd5b818114620001ba5760405163108cef9d60e31b815260040160405180910390fd5b6000805b828110156200020657858181518110620001dc57620001dc62000556565b602002602001015182620001f19190620006f4565b9150620001fe8162000582565b9050620001be565b508315806200021457508381105b15620002335760405163aabd5a0960e01b815260040160405180910390fd5b865160208089019190912060008181526002909252604090912054156200026d5760405163adda47f760e01b815260040160405180910390fd5b600080546200027e906001620006f4565b6000818155818152600160209081526040808320869055858352600290915290819020829055519091507f05b53362d4afea7533e835bd99f6c0f2c251e2f08b5c461734829516519dd5ac90620002db908a908a908a906200070f565b60405180910390a1505050505050505050565b80516000908183818362000306576200030662000556565b6020026020010151905060006001600160a01b0316816001600160a01b0316141562000336575060009392505050565b60015b828110156200039e57600085828151811062000359576200035962000556565b60200260200101519050806001600160a01b0316836001600160a01b031610620003895750600095945050505050565b9150620003968162000582565b905062000339565b506001949350505050565b634e487b7160e01b600052604160045260246000fd5b604051601f8201601f191681016001600160401b0381118282101715620003ea57620003ea620003a9565b604052919050565b60006001600160401b038211156200040e576200040e620003a9565b5060051b60200190565b600060208083850312156200042c57600080fd5b82516001600160401b03808211156200044457600080fd5b8185019150601f86818401126200045a57600080fd5b8251620004716200046b82620003f2565b620003bf565b81815260059190911b840185019085810190898311156200049157600080fd5b8686015b838110156200054857805186811115620004af5760008081fd5b8701603f81018c13620004c25760008081fd5b8881015187811115620004d957620004d9620003a9565b620004ec818801601f19168b01620003bf565b81815260408e81848601011115620005045760008081fd5b60005b8381101562000524578481018201518382018e01528c0162000507565b83811115620005365760008d85850101525b50508552505091870191870162000495565b509998505050505050505050565b634e487b7160e01b600052603260045260246000fd5b634e487b7160e01b600052601160045260246000fd5b60006000198214156200059957620005996200056c565b5060010190565b600082601f830112620005b257600080fd5b81516020620005c56200046b83620003f2565b82815260059290921b84018101918181019086841115620005e557600080fd5b8286015b84811015620006025780518352918301918301620005e9565b509695505050505050565b6000806000606084860312156200062357600080fd5b83516001600160401b03808211156200063b57600080fd5b818601915086601f8301126200065057600080fd5b81516020620006636200046b83620003f2565b82815260059290921b8401810191818101908a8411156200068357600080fd5b948201945b83861015620006ba5785516001600160a01b0381168114620006aa5760008081fd5b8252948201949082019062000688565b91890151919750909350505080821115620006d457600080fd5b50620006e386828701620005a0565b925050604084015190509250925092565b600082198211156200070a576200070a6200056c565b500190565b606080825284519082018190526000906020906080840190828801845b82811015620007535781516001600160a01b0316845292840192908401906001016200072c565b5050508381038285015285518082528683019183019060005b818110156200078a578351835292840192918401916001016200076c565b5050809350505050826040830152949350505050565b61112180620007b06000396000f3fe608060405234801561001057600080fd5b50600436106100be5760003560e01c8063ba6742e511610076578063e30c39781161005b578063e30c39781461018d578063f1501c89146101b4578063f2fde38b146101d457600080fd5b8063ba6742e51461015a578063d289d1cb1461017a57600080fd5b806376671808116100a7578063766718081461010057806379ba5097146101175780638da5cb5b1461011f57600080fd5b8063710bf322146100c357806373e3d66a146100d8575b600080fd5b6100d66100d1366004610b01565b6101e7565b005b6100eb6100e6366004610b6e565b6102b6565b60405190151581526020015b60405180910390f35b61010960005481565b6040519081526020016100f7565b6100d6610362565b7f02016836a56b71f0d02689e69e326f4f4c1b9057164ef592671cf0d37c8040c0545b6040516001600160a01b0390911681526020016100f7565b610109610168366004610bba565b60016020526000908152604090205481565b6100d6610188366004610bd3565b6103dc565b7f9855384122b55936fbfb8ca5120e63c6537a1ac40caf6ae33502b3c5da8c87d154610142565b6101096101c2366004610bba565b60026020526000908152604090205481565b6100d66101e2366004610b01565b61046f565b336102107f02016836a56b71f0d02689e69e326f4f4c1b9057164ef592671cf0d37c8040c05490565b6001600160a01b031614610237576040516330cd747160e01b815260040160405180910390fd5b6001600160a01b03811661025e57604051633649397d60e21b815260040160405180910390fd5b6040516001600160a01b038216907fd9be0e8e07417e00f2521db636cb53e316fd288f5051f16d2aa2bf0c3938a87690600090a27f9855384122b55936fbfb8ca5120e63c6537a1ac40caf6ae33502b3c5da8c87d155565b6000808080806102c886880188610dcf565b935093509350935060008484846040516020016102e793929190610ebf565b60408051601f19818403018152918152815160209283012060008181526002909352908220549154909250811580610329575060106103268383610f62565b10155b1561034757604051630849699d60e11b815260040160405180910390fd5b6103548b888888886104bf565b149998505050505050505050565b600061038c7f9855384122b55936fbfb8ca5120e63c6537a1ac40caf6ae33502b3c5da8c87d15490565b90506001600160a01b03811633146103d0576040517f49e27cff00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6103d981610611565b50565b336104057f02016836a56b71f0d02689e69e326f4f4c1b9057164ef592671cf0d37c8040c05490565b6001600160a01b03161461042c576040516330cd747160e01b815260040160405180910390fd5b61046b82828080601f0160208091040260200160405190810160405280939291908181526020018383808284376000920191909152506106b492505050565b5050565b336104987f02016836a56b71f0d02689e69e326f4f4c1b9057164ef592671cf0d37c8040c05490565b6001600160a01b0316146103d0576040516330cd747160e01b815260040160405180910390fd5b83518151600080805b838110156105d75760006104f58b8884815181106104e8576104e8610f79565b602002602001015161089a565b90505b8584108015610532575089848151811061051457610514610f79565b60200260200101516001600160a01b0316816001600160a01b031614155b156105475761054084610f8f565b93506104f8565b85841415610581576040517fc6fb539300000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b88848151811061059357610593610f79565b6020026020010151836105a69190610faa565b92508783106105ba5750505050505061060a565b6105c384610f8f565b935050806105d090610f8f565b90506104c8565b506040517f203b225800000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5050505050565b6001600160a01b03811661063857604051633649397d60e21b815260040160405180910390fd5b6040516001600160a01b038216907f04dba622d284ed0014ee4b9a6a68386be1a4c08a4913ae272de89199cc68616390600090a27f02016836a56b71f0d02689e69e326f4f4c1b9057164ef592671cf0d37c8040c05560007f9855384122b55936fbfb8ca5120e63c6537a1ac40caf6ae33502b3c5da8c87d155565b6000806000838060200190518101906106cd919061101d565b825182519396509194509250908115806106ed57506106eb85610a3d565b155b1561070b57604051630849699d60e11b815260040160405180910390fd5b818114610744576040517f84677ce800000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6000805b828110156107875785818151811061076257610762610f79565b6020026020010151826107759190610faa565b915061078081610f8f565b9050610748565b5083158061079457508381105b156107cb576040517faabd5a0900000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b8651602080890191909120600081815260029092526040909120541561081d576040517fadda47f700000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6000805461082c906001610faa565b6000818155818152600160209081526040808320869055858352600290915290819020829055519091507f05b53362d4afea7533e835bd99f6c0f2c251e2f08b5c461734829516519dd5ac90610887908a908a908a90610ebf565b60405180910390a1505050505050505050565b600081516041146108d7576040517f4be6321b00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b60208201516040830151606084015160001a7f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0821115610943576040517f40c1e74800000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b8060ff16601b1415801561095b57508060ff16601c14155b15610992576040517f119bce3900000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6040805160008082526020820180845289905260ff841692820192909252606081018590526080810184905260019060a0016020604051602081039080840390855afa1580156109e6573d6000803e3d6000fd5b505050602060405103519450846001600160a01b03161415610a34576040517f8baa579f00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b50505092915050565b805160009081838183610a5257610a52610f79565b6020026020010151905060006001600160a01b0316816001600160a01b03161415610a81575060009392505050565b60015b82811015610ae1576000858281518110610aa057610aa0610f79565b60200260200101519050806001600160a01b0316836001600160a01b031610610acf5750600095945050505050565b9150610ada81610f8f565b9050610a84565b506001949350505050565b6001600160a01b03811681146103d957600080fd5b600060208284031215610b1357600080fd5b8135610b1e81610aec565b9392505050565b60008083601f840112610b3757600080fd5b50813567ffffffffffffffff811115610b4f57600080fd5b602083019150836020828501011115610b6757600080fd5b9250929050565b600080600060408486031215610b8357600080fd5b83359250602084013567ffffffffffffffff811115610ba157600080fd5b610bad86828701610b25565b9497909650939450505050565b600060208284031215610bcc57600080fd5b5035919050565b60008060208385031215610be657600080fd5b823567ffffffffffffffff811115610bfd57600080fd5b610c0985828601610b25565b90969095509350505050565b634e487b7160e01b600052604160045260246000fd5b604051601f8201601f1916810167ffffffffffffffff81118282101715610c5457610c54610c15565b604052919050565b600067ffffffffffffffff821115610c7657610c76610c15565b5060051b60200190565b600082601f830112610c9157600080fd5b81356020610ca6610ca183610c5c565b610c2b565b82815260059290921b84018101918181019086841115610cc557600080fd5b8286015b84811015610ce05780358352918301918301610cc9565b509695505050505050565b6000601f8381840112610cfd57600080fd5b82356020610d0d610ca183610c5c565b82815260059290921b85018101918181019087841115610d2c57600080fd5b8287015b84811015610dc357803567ffffffffffffffff80821115610d515760008081fd5b818a0191508a603f830112610d665760008081fd5b85820135604082821115610d7c57610d7c610c15565b610d8d828b01601f19168901610c2b565b92508183528c81838601011115610da45760008081fd5b8181850189850137506000908201870152845250918301918301610d30565b50979650505050505050565b60008060008060808587031215610de557600080fd5b843567ffffffffffffffff80821115610dfd57600080fd5b818701915087601f830112610e1157600080fd5b81356020610e21610ca183610c5c565b82815260059290921b8401810191818101908b841115610e4057600080fd5b948201945b83861015610e67578535610e5881610aec565b82529482019490820190610e45565b98505088013592505080821115610e7d57600080fd5b610e8988838901610c80565b9450604087013593506060870135915080821115610ea657600080fd5b50610eb387828801610ceb565b91505092959194509250565b606080825284519082018190526000906020906080840190828801845b82811015610f015781516001600160a01b031684529284019290840190600101610edc565b5050508381038285015285518082528683019183019060005b81811015610f3657835183529284019291840191600101610f1a565b5050809350505050826040830152949350505050565b634e487b7160e01b600052601160045260246000fd5b600082821015610f7457610f74610f4c565b500390565b634e487b7160e01b600052603260045260246000fd5b6000600019821415610fa357610fa3610f4c565b5060010190565b60008219821115610fbd57610fbd610f4c565b500190565b600082601f830112610fd357600080fd5b81516020610fe3610ca183610c5c565b82815260059290921b8401810191818101908684111561100257600080fd5b8286015b84811015610ce05780518352918301918301611006565b60008060006060848603121561103257600080fd5b835167ffffffffffffffff8082111561104a57600080fd5b818601915086601f83011261105e57600080fd5b8151602061106e610ca183610c5c565b82815260059290921b8401810191818101908a84111561108d57600080fd5b948201945b838610156110b45785516110a581610aec565b82529482019490820190611092565b918901519197509093505050808211156110cd57600080fd5b506110da86828701610fc2565b92505060408401519050925092509256fea264697066735822122000a64ea6e2ecc2ff26e827bebf43ad7ab6edee4322613dea4aa8b6e387c85ab464736f6c6343000809003300000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000001800000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000004ba0ff557649fc7a5a6c54c166d024a8c4646fe6000000000000000000000000c84f53eb743e45204a7e3756b984368c25a68a1b00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000010000000000000000000000004ba0ff557649fc7a5a6c54c166d024a8c4646fe600000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001","accessList":null}, error={"name":"ProviderError","_stack":"ProviderError: execution reverted\n    at HttpProvider.request (/Users/isaacmarkus/axelar-cgp-solidity/node_modules/hardhat/src/internal/core/providers/http.ts:90:21)\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at EthersProviderWrapper.send (/Users/isaacmarkus/axelar-cgp-solidity/node_modules/@nomiclabs/hardhat-ethers/src/internal/ethers-provider-wrapper.ts:13:20)","code":3,"_isProviderError":true,"data":"0xaabd5a09"}, code=UNPREDICTABLE_GAS_LIMIT, version=providers/5.7.2)
      at Logger.makeError (node_modules/@ethersproject/logger/src.ts/index.ts:269:28)
      at Logger.throwError (node_modules/@ethersproject/logger/src.ts/index.ts:281:20)
      at checkError (node_modules/@ethersproject/providers/src.ts/json-rpc-provider.ts:78:20)
      at EthersProviderWrapper.<anonymous> (node_modules/@ethersproject/providers/src.ts/json-rpc-provider.ts:642:20)
      at step (node_modules/@ethersproject/providers/lib/json-rpc-provider.js:48:23)
      at Object.throw (node_modules/@ethersproject/providers/lib/json-rpc-provider.js:29:53)
      at rejected (node_modules/@ethersproject/providers/lib/json-rpc-provider.js:21:65)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)

  11) AxelarGasService
       AxelarGasService
         should emit events when receives gas payment:
     Error: Multiple transactions found in block
      at ensure (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/calledOnContract/utils.ts:13:11)
      at getBalanceChange (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/changeEtherBalance.ts:78:9)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async Promise.all (index 0)
      at Context.<anonymous> (test/gmp/AxelarGasService.js:120:13)

  12) AxelarGasService
       AxelarGasService
         should allow to collect accumulated payments and refund:
     Error: Multiple transactions found in block
      at ensure (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/calledOnContract/utils.ts:13:11)
      at getBalanceChange (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/changeEtherBalance.ts:78:9)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async Promise.all (index 0)
      at Context.<anonymous> (test/gmp/AxelarGasService.js:310:13)

  13) AxelarGasService
       AxelarGasService
         should allow to collect accumulated payments and refund with the new method:
     Error: Multiple transactions found in block
      at ensure (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/calledOnContract/utils.ts:13:11)
      at getBalanceChange (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/changeEtherBalance.ts:78:9)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async Promise.all (index 0)
      at Context.<anonymous> (test/gmp/AxelarGasService.js:448:13)

  14) AxelarGasService
       AxelarGasService
         should emit events when gas is added:
     Error: Multiple transactions found in block
      at ensure (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/calledOnContract/utils.ts:13:11)
      at getBalanceChange (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/changeEtherBalance.ts:78:9)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async Promise.all (index 0)
      at Context.<anonymous> (test/gmp/AxelarGasService.js:586:13)

  15) AxelarGasService
       AxelarGasService
         should emit events when gas is added for express calls:
     Error: Multiple transactions found in block
      at ensure (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/calledOnContract/utils.ts:13:11)
      at getBalanceChange (node_modules/@nomicfoundation/hardhat-chai-matchers/src/internal/changeEtherBalance.ts:78:9)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async Promise.all (index 0)
      at Context.<anonymous> (test/gmp/AxelarGasService.js:611:13)

  16) GeneralMessagePassing
       "before each" hook for "should swap tokens on remote chain":
     TypeError: Cannot read properties of undefined (reading 'address')
      at Context.<anonymous> (test/gmp/GeneralMessagePassing.js:175:91)



isaacmarkus@Mac axelar-cgp-solidity % 