### PR TITLE
docs: update README to remove deposit service reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See the Axelar contract deployments [repository](https://github.com/axelarnetwor
 
 1. [Gateway deployment](https://github.com/axelarnetwork/axelar-contract-deployments/tree/main/evm#axelargateway)
 2. [Gateway upgrade](https://github.com/axelarnetwork/axelar-contract-deployments/tree/main/evm#gateway-upgrade)
-3. [Gas service and deposit service deployment and upgrades](https://github.com/axelarnetwork/axelar-contract-deployments/tree/main/evm#axelargasservice-and-axelardepositservice)
+3. [Gas service deployment and upgrades](https://github.com/axelarnetwork/axelar-contract-deployments/tree/main/evm#axelargasservice)
 
 ## Live network testing
 


### PR DESCRIPTION
Update deployment docs link to reflect the removal of AxelarDepositService
Follows up on #309 which removed the deprecated sendToken and deposit service.

Part of CPI-116