### PR TITLE
chore: add catch-up changesets for changes since v6.4.0

### DIFF
--- a/.changeset/future-block-compat-test.md
+++ b/.changeset/future-block-compat-test.md
@@ -1,0 +1,5 @@
+---
+'@axelar-network/axelar-cgp-solidity': minor
+---
+
+feat: add future block compatibility test (#297)

--- a/.changeset/gmp-sdk-build-errors.md
+++ b/.changeset/gmp-sdk-build-errors.md
@@ -1,0 +1,5 @@
+---
+'@axelar-network/axelar-cgp-solidity': patch
+---
+
+fix: build errors for gmp-sdk-solidity upgrade (#293)

--- a/.changeset/operator-epoch-hash-encoding.md
+++ b/.changeset/operator-epoch-hash-encoding.md
@@ -1,0 +1,5 @@
+---
+'@axelar-network/axelar-cgp-solidity': patch
+---
+
+fix: use canonical ABI encoding for operator epoch hash (#310)

--- a/.changeset/remove-deprecated-services.md
+++ b/.changeset/remove-deprecated-services.md
@@ -1,0 +1,5 @@
+---
+'@axelar-network/axelar-cgp-solidity': minor
+---
+
+refactor: remove the deprecated `sendToken` and deposit service (#309)

--- a/.changeset/topic-order-match.md
+++ b/.changeset/topic-order-match.md
@@ -1,0 +1,5 @@
+---
+'@axelar-network/axelar-cgp-solidity': patch
+---
+
+fix: match for topic occurrence regardless of the order (#299)


### PR DESCRIPTION
Add changelogs for older items. To have them added in the Changelog upon release.


  | File | Bump | Original PR |
  |---|---|---|
  | `remove-deprecated-services.md` | minor | #309 — remove the deprecated `sendToken` and deposit service |
  | `future-block-compat-test.md` | minor | #297 — add future block compatibility test |
  | `operator-epoch-hash-encoding.md` | patch | #310 — use canonical ABI encoding for operator epoch hash |
  | `topic-order-match.md` | patch | #299 — match for topic occurrence regardless of order |
  | `gmp-sdk-build-errors.md` | patch | #293 — build errors for gmp-sdk-solidity upgrade |
