### PR TITLE
chore: bump @axelar-network/axelar-gmp-sdk-solidity to 6.1.0

### DIFF
--- a/.changeset/bump-gmp-sdk-6.1.0.md
+++ b/.changeset/bump-gmp-sdk-6.1.0.md
@@ -1,0 +1,5 @@
+---
+'@axelar-network/axelar-cgp-solidity': patch
+---
+
+chore: bump @axelar-network/axelar-gmp-sdk-solidity to 6.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.4.0",
       "license": "MIT",
       "dependencies": {
-        "@axelar-network/axelar-gmp-sdk-solidity": "6.0.6"
+        "@axelar-network/axelar-gmp-sdk-solidity": "6.1.0"
       },
       "devDependencies": {
         "@0xpolygonhermez/zkevm-commonjs": "github:0xpolygonhermez/zkevm-commonjs#v1.0.0",
@@ -76,9 +76,10 @@
       }
     },
     "node_modules/@axelar-network/axelar-gmp-sdk-solidity": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@axelar-network/axelar-gmp-sdk-solidity/-/axelar-gmp-sdk-solidity-6.0.6.tgz",
-      "integrity": "sha512-XIcDlr1HoYSqcxuvvusILmiqerh2bL9NJLwU4lFBAJK5E/st/q3Em9ropBBZML9iuUZ+hDsch8Ev9rMO+ulaSQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@axelar-network/axelar-gmp-sdk-solidity/-/axelar-gmp-sdk-solidity-6.1.0.tgz",
+      "integrity": "sha512-//m3rPb/mRpyzy4WXrrZN/5Z21PW1l7mHmn4cCujorTQeMwaPTecWq/5s15iemmOvr2xVozRWJ5vGbsRfcXn7A==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/axelarnetwork/axelar-cgp-solidity#readme",
   "dependencies": {
-    "@axelar-network/axelar-gmp-sdk-solidity": "6.0.6"
+    "@axelar-network/axelar-gmp-sdk-solidity": "6.1.0"
   },
   "devDependencies": {
     "@0xpolygonhermez/zkevm-commonjs": "github:0xpolygonhermez/zkevm-commonjs#v1.0.0",


### PR DESCRIPTION
bump @axelar-network/axelar-gmp-sdk-solidity to 6.1.0, which includes the `sendtoken` removal

Part of CPI-266