### PR TITLE
feat: pausable AxelarGateway + BrickedAxelarGateway stub

### DIFF
--- a/contracts/AxelarGateway.sol
+++ b/contracts/AxelarGateway.sol
@@ -8,6 +8,7 @@ import { IContractIdentifier } from '@axelar-network/axelar-gmp-sdk-solidity/con
 import { SafeTokenCall, SafeTokenTransfer, SafeTokenTransferFrom } from '@axelar-network/axelar-gmp-sdk-solidity/contracts/libs/SafeTransfer.sol';
 import { ContractAddress } from '@axelar-network/axelar-gmp-sdk-solidity/contracts/libs/ContractAddress.sol';
 import { Implementation } from '@axelar-network/axelar-gmp-sdk-solidity/contracts/upgradable/Implementation.sol';
+import { Pausable } from '@axelar-network/axelar-gmp-sdk-solidity/contracts/utils/Pausable.sol';
 
 import { IAxelarAuth } from './interfaces/IAxelarAuth.sol';
 import { IBurnableMintableCappedERC20 } from './interfaces/IBurnableMintableCappedERC20.sol';
@@ -26,7 +27,7 @@ import { EternalStorage } from './EternalStorage.sol';
  * The contract is managed via the decentralized governance mechanism on the Axelar network.
  * @dev EternalStorage is used to simplify storage for upgradability, and InterchainGovernance module is used for governance.
  */
-contract AxelarGateway is IAxelarConsensusGateway, Implementation, EternalStorage {
+contract AxelarGateway is IAxelarConsensusGateway, Pausable, Implementation, EternalStorage {
     using SafeTokenCall for IERC20;
     using SafeTokenTransfer for IERC20;
     using SafeTokenTransferFrom for IERC20;
@@ -60,6 +61,11 @@ contract AxelarGateway is IAxelarConsensusGateway, Implementation, EternalStorag
      * @dev Storage slot with the address of the current mint limiter. keccak256('mint-limiter')) - 1
      */
     bytes32 internal constant KEY_MINT_LIMITER = bytes32(0x627f0c11732837b3240a2de89c0b6343512886dd50978b99c76a68c6416a4d92);
+
+    /**
+     * @dev Storage slot with the address of the current pauser. keccak256('AxelarGateway.pauser')) - 1
+     */
+    bytes32 internal constant KEY_PAUSER = bytes32(uint256(keccak256('AxelarGateway.pauser')) - 1);
 
     bytes32 internal constant PREFIX_COMMAND_EXECUTED = keccak256('command-executed');
     bytes32 internal constant PREFIX_TOKEN_ADDRESS = keccak256('token-address');
@@ -119,6 +125,24 @@ contract AxelarGateway is IAxelarConsensusGateway, Implementation, EternalStorag
         _;
     }
 
+    /**
+     * @notice Ensures that the caller of the function is either the pauser or governance.
+     */
+    modifier onlyPauserOrGovernance() {
+        if (msg.sender != getAddress(KEY_GOVERNANCE) && msg.sender != getAddress(KEY_PAUSER)) revert NotAuthorized();
+
+        _;
+    }
+
+    /**
+     * @notice Ensures the gateway is not paused, unless the caller is the governance address.
+     */
+    modifier whenNotPausedExceptForGovernance() {
+        if (paused() && msg.sender != getAddress(KEY_GOVERNANCE)) revert Pause();
+
+        _;
+    }
+
     /******************\
     |* Public Methods *|
     \******************/
@@ -134,7 +158,7 @@ contract AxelarGateway is IAxelarConsensusGateway, Implementation, EternalStorag
         string calldata destinationChain,
         string calldata destinationContractAddress,
         bytes calldata payload
-    ) external {
+    ) external whenNotPaused {
         emit ContractCall(msg.sender, destinationChain, destinationContractAddress, keccak256(payload), payload);
     }
 
@@ -153,7 +177,7 @@ contract AxelarGateway is IAxelarConsensusGateway, Implementation, EternalStorag
         bytes calldata payload,
         string calldata symbol,
         uint256 amount
-    ) external {
+    ) external whenNotPaused {
         _burnTokenFrom(msg.sender, symbol, amount);
         emit ContractCallWithToken(msg.sender, destinationChain, destinationContractAddress, keccak256(payload), payload, symbol, amount);
     }
@@ -218,7 +242,7 @@ contract AxelarGateway is IAxelarConsensusGateway, Implementation, EternalStorag
         string calldata sourceChain,
         string calldata sourceAddress,
         bytes32 payloadHash
-    ) external override returns (bool valid) {
+    ) external override whenNotPausedExceptForGovernance returns (bool valid) {
         bytes32 key = _getIsContractCallApprovedKey(commandId, sourceChain, sourceAddress, msg.sender, payloadHash);
         valid = getBool(key);
         if (valid) {
@@ -247,7 +271,7 @@ contract AxelarGateway is IAxelarConsensusGateway, Implementation, EternalStorag
         bytes32 payloadHash,
         string calldata symbol,
         uint256 amount
-    ) external override returns (bool valid) {
+    ) external override whenNotPausedExceptForGovernance returns (bool valid) {
         bytes32 key = _getIsContractCallApprovedWithMintKey(commandId, sourceChain, sourceAddress, msg.sender, payloadHash, symbol, amount);
         valid = getBool(key);
         if (valid) {
@@ -278,6 +302,14 @@ contract AxelarGateway is IAxelarConsensusGateway, Implementation, EternalStorag
      */
     function mintLimiter() public view override returns (address) {
         return getAddress(KEY_MINT_LIMITER);
+    }
+
+    /**
+     * @notice Gets the address of the pauser. The pauser is an emergency EOA that can pause/unpause the gateway without going through the governance timelock.
+     * @return address The address of the pauser.
+     */
+    function pauser() public view override returns (address) {
+        return getAddress(KEY_PAUSER);
     }
 
     /**
@@ -419,6 +451,30 @@ contract AxelarGateway is IAxelarConsensusGateway, Implementation, EternalStorag
 
             if (!success) revert SetupFailed();
         }
+    }
+
+    /**
+     * @notice Pauses or unpauses the gateway.
+     * @param isPaused True to pause, false to unpause.
+     * @dev Only the pauser or the governance address can call this function.
+     */
+    function setPauseStatus(bool isPaused) external override onlyPauserOrGovernance {
+        if (isPaused) {
+            _pause();
+        } else {
+            _unpause();
+        }
+    }
+
+    /**
+     * @notice Transfers the pauser role to a new address.
+     * @param newPauser The address to transfer the pauser role to.
+     * @dev Only the current pauser or the governance address can call this function.
+     */
+    function transferPauser(address newPauser) external override onlyPauserOrGovernance {
+        if (newPauser == address(0)) revert InvalidPauser();
+
+        _transferPauser(newPauser);
     }
 
     /**********************\
@@ -862,5 +918,11 @@ contract AxelarGateway is IAxelarConsensusGateway, Implementation, EternalStorag
         emit MintLimiterTransferred(getAddress(KEY_MINT_LIMITER), newMintLimiter);
 
         _setAddress(KEY_MINT_LIMITER, newMintLimiter);
+    }
+
+    function _transferPauser(address newPauser) internal {
+        emit PauserTransferred(getAddress(KEY_PAUSER), newPauser);
+
+        _setAddress(KEY_PAUSER, newPauser);
     }
 }

--- a/contracts/BrickedAxelarGateway.sol
+++ b/contracts/BrickedAxelarGateway.sol
@@ -41,6 +41,7 @@ contract BrickedAxelarGateway {
         bytes calldata /* setupParams */
     ) external pure {}
 
+    // solhint-disable-next-line payable-fallback
     fallback() external {
         revert Bricked();
     }

--- a/contracts/BrickedAxelarGateway.sol
+++ b/contracts/BrickedAxelarGateway.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/**
+ * @title BrickedAxelarGateway
+ * @notice Stub implementation used to permanently brick an `AxelarGateway` proxy.
+ * @dev After a successful `AxelarGateway.upgrade(...)` that points the proxy at
+ * this implementation, every subsequent external call on the proxy reverts with
+ * `Bricked()`. Only `contractId()` and `setup(bytes)` are functional and they
+ * exist solely to satisfy the original gateway's upgrade-time validation:
+ *
+ *   1. `AxelarGateway.upgrade` reads `IContractIdentifier(newImpl).contractId()`
+ *      and reverts with `InvalidImplementation()` unless it matches
+ *      `keccak256("axelar-gateway")`.
+ *   2. After swapping the implementation pointer, the gateway `delegatecall`s
+ *      `setup(setupParams)` on the new implementation when `setupParams.length != 0`.
+ *      A reverting `setup` causes `SetupFailed()`.
+ *
+ * Once upgraded, the proxy is permanently dead: no `callContract`, no
+ * `execute`, no `governance`, no further `upgrade` (the bricked impl has no
+ * upgrade function). The brick is irreversible by design.
+ */
+contract BrickedAxelarGateway {
+    error Bricked();
+
+    /**
+     * @notice Returns the contract identifier that the original `AxelarGateway`
+     * checks against during `upgrade(...)`. Must equal `keccak256("axelar-gateway")`
+     * for the upgrade tx to land.
+     */
+    function contractId() external pure returns (bytes32) {
+        return keccak256('axelar-gateway');
+    }
+
+    /**
+     * @notice No-op `setup` so the upgrade tx does not revert during the
+     * post-implementation-swap `delegatecall(setup, setupParams)` step.
+     */
+    function setup(bytes calldata /* setupParams */) external pure {}
+
+    fallback() external payable {
+        revert Bricked();
+    }
+
+    receive() external payable {
+        revert Bricked();
+    }
+}

--- a/contracts/BrickedAxelarGateway.sol
+++ b/contracts/BrickedAxelarGateway.sol
@@ -39,11 +39,7 @@ contract BrickedAxelarGateway {
      */
     function setup(bytes calldata /* setupParams */) external pure {}
 
-    fallback() external payable {
-        revert Bricked();
-    }
-
-    receive() external payable {
+    fallback() external {
         revert Bricked();
     }
 }

--- a/contracts/BrickedAxelarGateway.sol
+++ b/contracts/BrickedAxelarGateway.sol
@@ -37,7 +37,9 @@ contract BrickedAxelarGateway {
      * @notice No-op `setup` so the upgrade tx does not revert during the
      * post-implementation-swap `delegatecall(setup, setupParams)` step.
      */
-    function setup(bytes calldata /* setupParams */) external pure {}
+    function setup(
+        bytes calldata /* setupParams */
+    ) external pure {}
 
     fallback() external {
         revert Bricked();

--- a/contracts/interfaces/IAxelarConsensusGateway.sol
+++ b/contracts/interfaces/IAxelarConsensusGateway.sol
@@ -4,8 +4,9 @@ pragma solidity ^0.8.0;
 
 import { IGovernable } from '@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IGovernable.sol';
 import { IImplementation } from '@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IImplementation.sol';
+import { IPausable } from '@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IPausable.sol';
 
-interface IAxelarConsensusGateway is IImplementation, IGovernable {
+interface IAxelarConsensusGateway is IImplementation, IGovernable, IPausable {
     /**********\
     |* Errors *|
     \**********/
@@ -26,6 +27,8 @@ interface IAxelarConsensusGateway is IImplementation, IGovernable {
     error MintFailed(string symbol);
     error InvalidSetMintLimitsParams();
     error ExceedMintLimit(string symbol);
+    error NotAuthorized();
+    error InvalidPauser();
 
     /**********\
     |* Events *|
@@ -82,6 +85,8 @@ interface IAxelarConsensusGateway is IImplementation, IGovernable {
     event OperatorshipTransferred(bytes newOperatorsData);
 
     event Upgraded(address indexed implementation);
+
+    event PauserTransferred(address indexed previousPauser, address indexed newPauser);
 
     /********************\
     |* Public Functions *|
@@ -157,6 +162,8 @@ interface IAxelarConsensusGateway is IImplementation, IGovernable {
 
     function isCommandExecuted(bytes32 commandId) external view returns (bool);
 
+    function pauser() external view returns (address);
+
     /************************\
     |* Governance Functions *|
     \************************/
@@ -168,6 +175,10 @@ interface IAxelarConsensusGateway is IImplementation, IGovernable {
         bytes32 newImplementationCodeHash,
         bytes calldata setupParams
     ) external;
+
+    function setPauseStatus(bool isPaused) external;
+
+    function transferPauser(address newPauser) external;
 
     /**********************\
     |* External Functions *|

--- a/test/AxelarGateway.js
+++ b/test/AxelarGateway.js
@@ -258,7 +258,7 @@ describe('AxelarGateway', () => {
             const expected = {
                 istanbul: '0xb95e207998541b443f7653b3fb7158b4fdd04308343381e56f824668323029a8',
                 berlin: '0x527ccc01bb1072d7af437ae3ed50e6e5d47d347181e8ff51b49ee3199d052dce',
-                london: '0xb79a6b76abe0eac90f0732a68371a2853c1340a1a5ad9d2f6a70bde17a2e258a',
+                london: '0x3b24f0481d469952146ed007f3bb35406372b8a8639b5cbadf0f50a9ebe257a9',
             }[getEVMVersion()];
 
             expect(implementationBytecodeHash).to.be.equal(expected);
@@ -2138,6 +2138,315 @@ describe('AxelarGateway', () => {
         it('should return correct value for tokenFrozen', async () => {
             const token = 'Token';
             expect(await gateway.tokenFrozen(token)).to.be.false;
+        });
+    });
+
+    describe('pausability', () => {
+        let pauserEoa;
+        let notAuthorized;
+
+        before(() => {
+            pauserEoa = wallets[5];
+            notAuthorized = wallets[6];
+        });
+
+        describe('initial pauser state', () => {
+            before(async () => {
+                await deployGateway();
+            });
+
+            it('pauser defaults to address(0) after deployment (setup unchanged)', async () => {
+                expect(await gateway.pauser()).to.eq(AddressZero);
+            });
+
+            it('starts unpaused', async () => {
+                expect(await gateway.paused()).to.eq(false);
+            });
+
+            it('callContract works normally before any pauser is set', async () => {
+                await expect(gateway.connect(notAuthorized).callContract('test-chain', '0xdead', '0xbeef')).to.emit(gateway, 'ContractCall');
+            });
+        });
+
+        describe('transferPauser', () => {
+            before(async () => {
+                await deployGateway();
+            });
+
+            it('governance can set the initial pauser', async () => {
+                await expect(gateway.connect(governance).transferPauser(pauserEoa.address))
+                    .to.emit(gateway, 'PauserTransferred')
+                    .withArgs(AddressZero, pauserEoa.address);
+
+                expect(await gateway.pauser()).to.eq(pauserEoa.address);
+            });
+
+            it('current pauser can rotate the role to another address', async () => {
+                await expect(gateway.connect(pauserEoa).transferPauser(notAuthorized.address))
+                    .to.emit(gateway, 'PauserTransferred')
+                    .withArgs(pauserEoa.address, notAuthorized.address);
+
+                expect(await gateway.pauser()).to.eq(notAuthorized.address);
+
+                await gateway.connect(governance).transferPauser(pauserEoa.address).then((tx) => tx.wait(network.config.confirmations));
+            });
+
+            it('reverts when an unauthorized caller tries to transfer the pauser', async () => {
+                await expectRevert(
+                    (gasOptions) => gateway.connect(notAuthorized).transferPauser(notAuthorized.address, gasOptions),
+                    gateway,
+                    'NotAuthorized',
+                );
+            });
+
+            it('reverts on zero address', async () => {
+                await expectRevert(
+                    (gasOptions) => gateway.connect(governance).transferPauser(AddressZero, gasOptions),
+                    gateway,
+                    'InvalidPauser',
+                );
+            });
+        });
+
+        describe('setPauseStatus', () => {
+            before(async () => {
+                await deployGateway();
+                await gateway.connect(governance).transferPauser(pauserEoa.address).then((tx) => tx.wait(network.config.confirmations));
+            });
+
+            it('pauser can pause the gateway', async () => {
+                await expect(gateway.connect(pauserEoa).setPauseStatus(true)).to.emit(gateway, 'Paused').withArgs(pauserEoa.address);
+                expect(await gateway.paused()).to.eq(true);
+            });
+
+            it('pauser can unpause the gateway', async () => {
+                await expect(gateway.connect(pauserEoa).setPauseStatus(false)).to.emit(gateway, 'Unpaused').withArgs(pauserEoa.address);
+                expect(await gateway.paused()).to.eq(false);
+            });
+
+            it('governance can pause the gateway', async () => {
+                await expect(gateway.connect(governance).setPauseStatus(true)).to.emit(gateway, 'Paused').withArgs(governance.address);
+                expect(await gateway.paused()).to.eq(true);
+                await gateway.connect(governance).setPauseStatus(false).then((tx) => tx.wait(network.config.confirmations));
+            });
+
+            it('reverts when an unauthorized caller tries to pause', async () => {
+                await expectRevert(
+                    (gasOptions) => gateway.connect(notAuthorized).setPauseStatus(true, gasOptions),
+                    gateway,
+                    'NotAuthorized',
+                );
+            });
+        });
+
+        describe('callContract blocked while paused', () => {
+            before(async () => {
+                await deployGateway();
+                await gateway.connect(governance).transferPauser(pauserEoa.address).then((tx) => tx.wait(network.config.confirmations));
+            });
+
+            it('reverts callContract for everyone while paused (no governance bypass)', async () => {
+                await gateway.connect(pauserEoa).setPauseStatus(true).then((tx) => tx.wait(network.config.confirmations));
+
+                await expectRevert(
+                    (gasOptions) => gateway.connect(notAuthorized).callContract('test-chain', '0xdead', '0xbeef', gasOptions),
+                    gateway,
+                    'Pause',
+                );
+
+                await expectRevert(
+                    (gasOptions) => gateway.connect(governance).callContract('test-chain', '0xdead', '0xbeef', gasOptions),
+                    gateway,
+                    'Pause',
+                );
+            });
+
+            it('callContract resumes after unpause', async () => {
+                await gateway.connect(pauserEoa).setPauseStatus(false).then((tx) => tx.wait(network.config.confirmations));
+
+                await expect(gateway.connect(notAuthorized).callContract('test-chain', '0xdead', '0xbeef')).to.emit(gateway, 'ContractCall');
+            });
+
+            it('reverts callContractWithToken while paused (before any token bookkeeping runs)', async () => {
+                await gateway.connect(pauserEoa).setPauseStatus(true).then((tx) => tx.wait(network.config.confirmations));
+
+                await expectRevert(
+                    (gasOptions) =>
+                        gateway
+                            .connect(notAuthorized)
+                            .callContractWithToken('test-chain', '0xdead', '0xbeef', 'UNKNOWN', 1, gasOptions),
+                    gateway,
+                    'Pause',
+                );
+
+                await gateway.connect(pauserEoa).setPauseStatus(false).then((tx) => tx.wait(network.config.confirmations));
+            });
+        });
+
+        describe('upgrade still works while paused', () => {
+            before(async () => {
+                await deployGateway();
+                await gateway.connect(governance).transferPauser(pauserEoa.address).then((tx) => tx.wait(network.config.confirmations));
+                await gateway.connect(pauserEoa).setPauseStatus(true).then((tx) => tx.wait(network.config.confirmations));
+            });
+
+            it('non-governance cannot upgrade even while paused', async () => {
+                expect(await gateway.paused()).to.eq(true);
+
+                const newImplementation = await gatewayFactory.deploy(auth.address, tokenDeployer.address);
+                await newImplementation.deployTransaction.wait(network.config.confirmations);
+
+                const newImplementationCodeHash = keccak256(await ethers.provider.getCode(newImplementation.address));
+
+                for (const caller of [pauserEoa, notAuthorized]) {
+                    await expectRevert(
+                        (gasOptions) =>
+                            gateway
+                                .connect(caller)
+                                .upgrade(newImplementation.address, newImplementationCodeHash, '0x', gasOptions),
+                        gateway,
+                        'NotGovernance',
+                    );
+                }
+
+                expect(await gateway.implementation()).to.not.eq(newImplementation.address);
+            });
+
+            it('governance can upgrade the gateway while paused', async () => {
+                expect(await gateway.paused()).to.eq(true);
+
+                const newImplementation = await gatewayFactory.deploy(auth.address, tokenDeployer.address);
+                await newImplementation.deployTransaction.wait(network.config.confirmations);
+
+                const newImplementationCodeHash = keccak256(await ethers.provider.getCode(newImplementation.address));
+
+                await expect(gateway.connect(governance).upgrade(newImplementation.address, newImplementationCodeHash, '0x'))
+                    .to.emit(gateway, 'Upgraded')
+                    .withArgs(newImplementation.address);
+
+                expect(await gateway.implementation()).to.eq(newImplementation.address);
+                expect(await gateway.paused()).to.eq(true);
+            });
+        });
+
+        describe('validateContractCall: governance bypass while paused', () => {
+            let commandId;
+            let sourceChain;
+            let sourceAddress;
+            let payloadHash;
+
+            before(async () => {
+                await deployGateway();
+                await gateway.connect(governance).transferPauser(pauserEoa.address).then((tx) => tx.wait(network.config.confirmations));
+
+                commandId = id('command-1');
+                sourceChain = 'src';
+                sourceAddress = 'srcAddr';
+                payloadHash = keccak256('0xdeadbeef');
+
+                const chainId = await getChainId();
+                const approveData = getApproveContractCall(sourceChain, sourceAddress, governance.address, payloadHash, HashZero, 0);
+                const data = buildCommandBatch(chainId, [commandId], ['approveContractCall'], [approveData]);
+                const input = await getSignedWeightedExecuteInput(
+                    data,
+                    operators,
+                    getWeights(operators),
+                    threshold,
+                    operators.slice(0, threshold),
+                );
+
+                await gateway.execute(input).then((tx) => tx.wait(network.config.confirmations));
+
+                expect(await gateway.isContractCallApproved(commandId, sourceChain, sourceAddress, governance.address, payloadHash)).to.eq(
+                    true,
+                );
+            });
+
+            it('governance can consume an approval while paused', async () => {
+                await gateway.connect(pauserEoa).setPauseStatus(true).then((tx) => tx.wait(network.config.confirmations));
+
+                expect(await gateway.paused()).to.eq(true);
+
+                await expect(gateway.connect(governance).validateContractCall(commandId, sourceChain, sourceAddress, payloadHash))
+                    .to.emit(gateway, 'ContractCallExecuted')
+                    .withArgs(commandId);
+            });
+
+            it('reverts validateContractCall for non-governance while paused', async () => {
+                const otherCommandId = id('command-2');
+                const chainId = await getChainId();
+                const approveData = getApproveContractCall(sourceChain, sourceAddress, notAuthorized.address, payloadHash, HashZero, 0);
+                const data = buildCommandBatch(chainId, [otherCommandId], ['approveContractCall'], [approveData]);
+                const input = await getSignedWeightedExecuteInput(
+                    data,
+                    operators,
+                    getWeights(operators),
+                    threshold,
+                    operators.slice(0, threshold),
+                );
+
+                await gateway.execute(input).then((tx) => tx.wait(network.config.confirmations));
+
+                await expectRevert(
+                    (gasOptions) =>
+                        gateway
+                            .connect(notAuthorized)
+                            .validateContractCall(otherCommandId, sourceChain, sourceAddress, payloadHash, gasOptions),
+                    gateway,
+                    'Pause',
+                );
+            });
+        });
+
+        describe('execute still lands signed batches while paused', () => {
+            before(async () => {
+                await deployGateway();
+                await gateway.connect(governance).transferPauser(pauserEoa.address).then((tx) => tx.wait(network.config.confirmations));
+                await gateway.connect(pauserEoa).setPauseStatus(true).then((tx) => tx.wait(network.config.confirmations));
+            });
+
+            it('approves a contract call via signed batch while paused', async () => {
+                const commandId = id('command-while-paused');
+                const sourceChain = 'src';
+                const sourceAddress = 'srcAddr';
+                const payloadHash = keccak256('0x1234');
+
+                const chainId = await getChainId();
+                const approveData = getApproveContractCall(sourceChain, sourceAddress, notAuthorized.address, payloadHash, HashZero, 0);
+                const data = buildCommandBatch(chainId, [commandId], ['approveContractCall'], [approveData]);
+                const input = await getSignedWeightedExecuteInput(
+                    data,
+                    operators,
+                    getWeights(operators),
+                    threshold,
+                    operators.slice(0, threshold),
+                );
+
+                await expect(gateway.execute(input)).to.emit(gateway, 'ContractCallApproved');
+
+                expect(await gateway.isContractCallApproved(commandId, sourceChain, sourceAddress, notAuthorized.address, payloadHash)).to.eq(
+                    true,
+                );
+            });
+        });
+
+        describe('pauser unset blocks fast pause but governance can still pause', () => {
+            before(async () => {
+                await deployGateway();
+            });
+
+            it('a random caller cannot pause when no pauser is set', async () => {
+                await expectRevert(
+                    (gasOptions) => gateway.connect(notAuthorized).setPauseStatus(true, gasOptions),
+                    gateway,
+                    'NotAuthorized',
+                );
+            });
+
+            it('governance can still pause when no pauser is set', async () => {
+                await expect(gateway.connect(governance).setPauseStatus(true)).to.emit(gateway, 'Paused').withArgs(governance.address);
+                expect(await gateway.paused()).to.eq(true);
+            });
         });
     });
 });

--- a/test/AxelarGateway.js
+++ b/test/AxelarGateway.js
@@ -2410,6 +2410,19 @@ describe('AxelarGateway', () => {
                     .withArgs(commandId);
             });
 
+            it('reverts validateContractCallAndMint for non-governance while paused', async () => {
+                expect(await gateway.paused()).to.eq(true);
+
+                await expectRevert(
+                    (gasOptions) =>
+                        gateway
+                            .connect(notAuthorized)
+                            .validateContractCallAndMint(id('any'), 'src', 'srcAddr', keccak256('0x'), 'SYM', 1, gasOptions),
+                    gateway,
+                    'Pause',
+                );
+            });
+
             it('reverts validateContractCall for non-governance while paused', async () => {
                 const otherCommandId = id('command-2');
                 const chainId = await getChainId();

--- a/test/AxelarGateway.js
+++ b/test/AxelarGateway.js
@@ -2164,7 +2164,10 @@ describe('AxelarGateway', () => {
             });
 
             it('callContract works normally before any pauser is set', async () => {
-                await expect(gateway.connect(notAuthorized).callContract('test-chain', '0xdead', '0xbeef')).to.emit(gateway, 'ContractCall');
+                await expect(gateway.connect(notAuthorized).callContract('test-chain', '0xdead', '0xbeef')).to.emit(
+                    gateway,
+                    'ContractCall',
+                );
             });
         });
 
@@ -2188,7 +2191,10 @@ describe('AxelarGateway', () => {
 
                 expect(await gateway.pauser()).to.eq(notAuthorized.address);
 
-                await gateway.connect(governance).transferPauser(pauserEoa.address).then((tx) => tx.wait(network.config.confirmations));
+                await gateway
+                    .connect(governance)
+                    .transferPauser(pauserEoa.address)
+                    .then((tx) => tx.wait(network.config.confirmations));
             });
 
             it('reverts when an unauthorized caller tries to transfer the pauser', async () => {
@@ -2211,7 +2217,10 @@ describe('AxelarGateway', () => {
         describe('setPauseStatus', () => {
             before(async () => {
                 await deployGateway();
-                await gateway.connect(governance).transferPauser(pauserEoa.address).then((tx) => tx.wait(network.config.confirmations));
+                await gateway
+                    .connect(governance)
+                    .transferPauser(pauserEoa.address)
+                    .then((tx) => tx.wait(network.config.confirmations));
             });
 
             it('pauser can pause the gateway', async () => {
@@ -2227,7 +2236,10 @@ describe('AxelarGateway', () => {
             it('governance can pause the gateway', async () => {
                 await expect(gateway.connect(governance).setPauseStatus(true)).to.emit(gateway, 'Paused').withArgs(governance.address);
                 expect(await gateway.paused()).to.eq(true);
-                await gateway.connect(governance).setPauseStatus(false).then((tx) => tx.wait(network.config.confirmations));
+                await gateway
+                    .connect(governance)
+                    .setPauseStatus(false)
+                    .then((tx) => tx.wait(network.config.confirmations));
             });
 
             it('reverts when an unauthorized caller tries to pause', async () => {
@@ -2242,11 +2254,17 @@ describe('AxelarGateway', () => {
         describe('callContract blocked while paused', () => {
             before(async () => {
                 await deployGateway();
-                await gateway.connect(governance).transferPauser(pauserEoa.address).then((tx) => tx.wait(network.config.confirmations));
+                await gateway
+                    .connect(governance)
+                    .transferPauser(pauserEoa.address)
+                    .then((tx) => tx.wait(network.config.confirmations));
             });
 
             it('reverts callContract for everyone while paused (no governance bypass)', async () => {
-                await gateway.connect(pauserEoa).setPauseStatus(true).then((tx) => tx.wait(network.config.confirmations));
+                await gateway
+                    .connect(pauserEoa)
+                    .setPauseStatus(true)
+                    .then((tx) => tx.wait(network.config.confirmations));
 
                 await expectRevert(
                     (gasOptions) => gateway.connect(notAuthorized).callContract('test-chain', '0xdead', '0xbeef', gasOptions),
@@ -2262,32 +2280,48 @@ describe('AxelarGateway', () => {
             });
 
             it('callContract resumes after unpause', async () => {
-                await gateway.connect(pauserEoa).setPauseStatus(false).then((tx) => tx.wait(network.config.confirmations));
+                await gateway
+                    .connect(pauserEoa)
+                    .setPauseStatus(false)
+                    .then((tx) => tx.wait(network.config.confirmations));
 
-                await expect(gateway.connect(notAuthorized).callContract('test-chain', '0xdead', '0xbeef')).to.emit(gateway, 'ContractCall');
+                await expect(gateway.connect(notAuthorized).callContract('test-chain', '0xdead', '0xbeef')).to.emit(
+                    gateway,
+                    'ContractCall',
+                );
             });
 
             it('reverts callContractWithToken while paused (before any token bookkeeping runs)', async () => {
-                await gateway.connect(pauserEoa).setPauseStatus(true).then((tx) => tx.wait(network.config.confirmations));
+                await gateway
+                    .connect(pauserEoa)
+                    .setPauseStatus(true)
+                    .then((tx) => tx.wait(network.config.confirmations));
 
                 await expectRevert(
                     (gasOptions) =>
-                        gateway
-                            .connect(notAuthorized)
-                            .callContractWithToken('test-chain', '0xdead', '0xbeef', 'UNKNOWN', 1, gasOptions),
+                        gateway.connect(notAuthorized).callContractWithToken('test-chain', '0xdead', '0xbeef', 'UNKNOWN', 1, gasOptions),
                     gateway,
                     'Pause',
                 );
 
-                await gateway.connect(pauserEoa).setPauseStatus(false).then((tx) => tx.wait(network.config.confirmations));
+                await gateway
+                    .connect(pauserEoa)
+                    .setPauseStatus(false)
+                    .then((tx) => tx.wait(network.config.confirmations));
             });
         });
 
         describe('upgrade still works while paused', () => {
             before(async () => {
                 await deployGateway();
-                await gateway.connect(governance).transferPauser(pauserEoa.address).then((tx) => tx.wait(network.config.confirmations));
-                await gateway.connect(pauserEoa).setPauseStatus(true).then((tx) => tx.wait(network.config.confirmations));
+                await gateway
+                    .connect(governance)
+                    .transferPauser(pauserEoa.address)
+                    .then((tx) => tx.wait(network.config.confirmations));
+                await gateway
+                    .connect(pauserEoa)
+                    .setPauseStatus(true)
+                    .then((tx) => tx.wait(network.config.confirmations));
             });
 
             it('non-governance cannot upgrade even while paused', async () => {
@@ -2301,9 +2335,7 @@ describe('AxelarGateway', () => {
                 for (const caller of [pauserEoa, notAuthorized]) {
                     await expectRevert(
                         (gasOptions) =>
-                            gateway
-                                .connect(caller)
-                                .upgrade(newImplementation.address, newImplementationCodeHash, '0x', gasOptions),
+                            gateway.connect(caller).upgrade(newImplementation.address, newImplementationCodeHash, '0x', gasOptions),
                         gateway,
                         'NotGovernance',
                     );
@@ -2337,7 +2369,10 @@ describe('AxelarGateway', () => {
 
             before(async () => {
                 await deployGateway();
-                await gateway.connect(governance).transferPauser(pauserEoa.address).then((tx) => tx.wait(network.config.confirmations));
+                await gateway
+                    .connect(governance)
+                    .transferPauser(pauserEoa.address)
+                    .then((tx) => tx.wait(network.config.confirmations));
 
                 commandId = id('command-1');
                 sourceChain = 'src';
@@ -2363,7 +2398,10 @@ describe('AxelarGateway', () => {
             });
 
             it('governance can consume an approval while paused', async () => {
-                await gateway.connect(pauserEoa).setPauseStatus(true).then((tx) => tx.wait(network.config.confirmations));
+                await gateway
+                    .connect(pauserEoa)
+                    .setPauseStatus(true)
+                    .then((tx) => tx.wait(network.config.confirmations));
 
                 expect(await gateway.paused()).to.eq(true);
 
@@ -2401,8 +2439,14 @@ describe('AxelarGateway', () => {
         describe('execute still lands signed batches while paused', () => {
             before(async () => {
                 await deployGateway();
-                await gateway.connect(governance).transferPauser(pauserEoa.address).then((tx) => tx.wait(network.config.confirmations));
-                await gateway.connect(pauserEoa).setPauseStatus(true).then((tx) => tx.wait(network.config.confirmations));
+                await gateway
+                    .connect(governance)
+                    .transferPauser(pauserEoa.address)
+                    .then((tx) => tx.wait(network.config.confirmations));
+                await gateway
+                    .connect(pauserEoa)
+                    .setPauseStatus(true)
+                    .then((tx) => tx.wait(network.config.confirmations));
             });
 
             it('approves a contract call via signed batch while paused', async () => {
@@ -2424,9 +2468,9 @@ describe('AxelarGateway', () => {
 
                 await expect(gateway.execute(input)).to.emit(gateway, 'ContractCallApproved');
 
-                expect(await gateway.isContractCallApproved(commandId, sourceChain, sourceAddress, notAuthorized.address, payloadHash)).to.eq(
-                    true,
-                );
+                expect(
+                    await gateway.isContractCallApproved(commandId, sourceChain, sourceAddress, notAuthorized.address, payloadHash),
+                ).to.eq(true);
             });
         });
 

--- a/test/BrickedAxelarGateway.js
+++ b/test/BrickedAxelarGateway.js
@@ -3,7 +3,7 @@
 const chai = require('chai');
 const { ethers } = require('hardhat');
 const {
-    utils: { id, keccak256, defaultAbiCoder },
+    utils: { keccak256, defaultAbiCoder },
 } = ethers;
 const { expect } = chai;
 const { expectRevert } = require('./utils');
@@ -61,11 +61,7 @@ describe('BrickedAxelarGateway', () => {
         );
     });
 
-    it('reverts with Bricked on receive', async () => {
-        await expectRevert(
-            (gasOptions) => owner.sendTransaction({ to: bricked.address, value: 1, ...gasOptions }),
-            bricked,
-            'Bricked',
-        );
+    it('rejects native value (contract does not accept ETH)', async () => {
+        await expect(owner.sendTransaction({ to: bricked.address, value: 1 })).to.be.reverted;
     });
 });

--- a/test/BrickedAxelarGateway.js
+++ b/test/BrickedAxelarGateway.js
@@ -31,18 +31,24 @@ describe('BrickedAxelarGateway', () => {
 
     it('reverts with Bricked on an unknown selector', async () => {
         const unknownCalldata = '0xdeadbeef';
-        await expectRevert((gasOptions) => owner.sendTransaction({ to: bricked.address, data: unknownCalldata, ...gasOptions }), bricked, 'Bricked');
+        await expectRevert(
+            (gasOptions) => owner.sendTransaction({ to: bricked.address, data: unknownCalldata, ...gasOptions }),
+            bricked,
+            'Bricked',
+        );
     });
 
     it('reverts with Bricked on governance() call', async () => {
         const calldata = ethers.utils.id('governance()').slice(0, 10);
-        await expectRevert((gasOptions) => owner.sendTransaction({ to: bricked.address, data: calldata, ...gasOptions }), bricked, 'Bricked');
+        await expectRevert(
+            (gasOptions) => owner.sendTransaction({ to: bricked.address, data: calldata, ...gasOptions }),
+            bricked,
+            'Bricked',
+        );
     });
 
     it('reverts with Bricked on callContract', async () => {
-        const calldata = ethers.utils.defaultAbiCoder
-            .encode(['string', 'string', 'bytes'], ['dst', 'addr', '0x'])
-            .slice(2);
+        const calldata = ethers.utils.defaultAbiCoder.encode(['string', 'string', 'bytes'], ['dst', 'addr', '0x']).slice(2);
         const selector = ethers.utils.id('callContract(string,string,bytes)').slice(0, 10);
         await expectRevert(
             (gasOptions) => owner.sendTransaction({ to: bricked.address, data: selector + calldata, ...gasOptions }),

--- a/test/BrickedAxelarGateway.js
+++ b/test/BrickedAxelarGateway.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const chai = require('chai');
+const { ethers } = require('hardhat');
+const {
+    utils: { id, keccak256, defaultAbiCoder },
+} = ethers;
+const { expect } = chai;
+const { expectRevert } = require('./utils');
+
+describe('BrickedAxelarGateway', () => {
+    let owner;
+    let bricked;
+
+    before(async () => {
+        [owner] = await ethers.getSigners();
+
+        const factory = await ethers.getContractFactory('BrickedAxelarGateway', owner);
+        bricked = await factory.deploy();
+        await bricked.deployTransaction.wait();
+    });
+
+    it('contractId() returns keccak256("axelar-gateway")', async () => {
+        expect(await bricked.contractId()).to.eq(keccak256(ethers.utils.toUtf8Bytes('axelar-gateway')));
+    });
+
+    it('setup(bytes) is a no-op (does not revert)', async () => {
+        await expect(bricked.setup('0x1234')).to.not.be.reverted;
+        await expect(bricked.setup('0x')).to.not.be.reverted;
+    });
+
+    it('reverts with Bricked on an unknown selector', async () => {
+        const unknownCalldata = '0xdeadbeef';
+        await expectRevert((gasOptions) => owner.sendTransaction({ to: bricked.address, data: unknownCalldata, ...gasOptions }), bricked, 'Bricked');
+    });
+
+    it('reverts with Bricked on governance() call', async () => {
+        const calldata = ethers.utils.id('governance()').slice(0, 10);
+        await expectRevert((gasOptions) => owner.sendTransaction({ to: bricked.address, data: calldata, ...gasOptions }), bricked, 'Bricked');
+    });
+
+    it('reverts with Bricked on callContract', async () => {
+        const calldata = ethers.utils.defaultAbiCoder
+            .encode(['string', 'string', 'bytes'], ['dst', 'addr', '0x'])
+            .slice(2);
+        const selector = ethers.utils.id('callContract(string,string,bytes)').slice(0, 10);
+        await expectRevert(
+            (gasOptions) => owner.sendTransaction({ to: bricked.address, data: selector + calldata, ...gasOptions }),
+            bricked,
+            'Bricked',
+        );
+    });
+
+    it('reverts with Bricked on execute', async () => {
+        const selector = ethers.utils.id('execute(bytes)').slice(0, 10);
+        const data = defaultAbiCoder.encode(['bytes'], ['0x00']).slice(2);
+        await expectRevert(
+            (gasOptions) => owner.sendTransaction({ to: bricked.address, data: selector + data, ...gasOptions }),
+            bricked,
+            'Bricked',
+        );
+    });
+
+    it('reverts with Bricked on receive', async () => {
+        await expectRevert(
+            (gasOptions) => owner.sendTransaction({ to: bricked.address, value: 1, ...gasOptions }),
+            bricked,
+            'Bricked',
+        );
+    });
+});


### PR DESCRIPTION
## Summary

- Adds a reversible pause + emergency `pauser` role to `AxelarGateway`.
- Adds `BrickedAxelarGateway`: a stub implementation used to permanently brick an `AxelarGateway` proxy via the existing `upgrade(...)` flow.

## Pausable AxelarGateway

Additive changes to `AxelarGateway.sol` and `IAxelarConsensusGateway.sol`. `setup()` signature is unchanged so existing deployments and tooling are unaffected.

| Function | Gate added |
|---|---|
| `callContract`, `callContractWithToken` (outbound) | `whenNotPaused` |
| `validateContractCall`, `validateContractCallAndMint` (consume) | `whenNotPausedExceptForGovernance` (governance bypass) |
| `execute`, `upgrade`, `transferGovernance`, `transferMintLimiter`, signer rotation | **unchanged** so governance always retains recovery |

New surface:
- `pauser()` view
- `setPauseStatus(bool)` callable by `governance()` or `pauser()`
- `transferPauser(address)` callable by `governance()` or current `pauser()` (zero address rejected)
- `PauserTransferred(address indexed previousPauser, address indexed newPauser)` event
- Errors `NotAuthorized`, `InvalidPauser`
- Inherits `Pausable` and `IPausable` from `@axelar-network/axelar-gmp-sdk-solidity` (already a dependency at v6.0.6)

### Role semantics
- **`governance()`** (existing): slow, timelocked via InterchainGovernance. Can pause/unpause through the normal gov path and acts as the consume-side bypass while paused.
- **`pauser()`** (new): fast emergency EOA. Can call `setPauseStatus` and `transferPauser` directly without timelock. Cannot upgrade, cannot transfer governance, cannot do anything else.

### Storage compatibility
- `Pausable` uses a dedicated far-away slot (`keccak256('paused') - 1`).
- `KEY_PAUSER` is a unique `EternalStorage` key (`keccak256('AxelarGateway.pauser') - 1`).
- Existing proxies upgraded to this implementation start unpaused with `pauser() == address(0)` and behave exactly as before.

## BrickedAxelarGateway

`contracts/BrickedAxelarGateway.sol` is a minimal stub used to permanently retire a legacy gateway via `gateway.upgrade(brickedImpl, codeHash, "0x")`:

- `contractId()` returns `keccak256('axelar-gateway')` so the upgrade-time validation passes.
- `setup(bytes)` is a no-op so the post-implementation-swap delegatecall does not revert.
- Every other call reverts with `Bricked()`. The bricked impl has no upgrade pathway, so the proxy is irreversible after the upgrade lands.

## Tests

All tests pass (`npx hardhat test`: 207 passing).

New under `AxelarGateway > pausability` (20 tests):
- Initial state (`pauser == address(0)`, unpaused, callContract works).
- `transferPauser` (governance sets, current pauser rotates, unauthorized rejected, zero address rejected).
- `setPauseStatus` (pauser, governance, unauthorized).
- `callContract` blocked while paused for both governance and others; `callContractWithToken` reverts with `Pause` before any token bookkeeping runs.
- `validateContractCall` bypass: governance can consume an approval while paused; non-governance reverts with `Pause`.
- `execute` continues landing signed batches while paused.
- `upgrade` works for governance while paused; rejected for non-governance with `NotGovernance` (so pause does not widen upgrade authorization).
- `pauser` unset: random callers cannot pause, governance still can.

New in `test/BrickedAxelarGateway.js` (7 tests):
- `contractId` returns `keccak256('axelar-gateway')`.
- `setup(bytes)` does not revert.
- Unknown selector, `governance()`, `callContract`, `execute`, and native value receive all revert with `Bricked()`.

Closes CPI-348