### PR TITLE
fix: revert native transfers to bricked gateway with Bricked

### DIFF
--- a/contracts/BrickedAxelarGateway.sol
+++ b/contracts/BrickedAxelarGateway.sol
@@ -41,6 +41,10 @@ contract BrickedAxelarGateway {
         bytes calldata /* setupParams */
     ) external pure {}
 
+    receive() external payable {
+        revert Bricked();
+    }
+
     // solhint-disable-next-line payable-fallback
     fallback() external {
         revert Bricked();

--- a/test/BrickedAxelarGateway.js
+++ b/test/BrickedAxelarGateway.js
@@ -68,6 +68,6 @@ describe('BrickedAxelarGateway', () => {
     });
 
     it('rejects native value (contract does not accept ETH)', async () => {
-        await expect(owner.sendTransaction({ to: bricked.address, value: 1 })).to.be.reverted;
+        await expectRevert((gasOptions) => owner.sendTransaction({ to: bricked.address, value: 1, ...gasOptions }), bricked, 'Bricked');
     });
 });


### PR DESCRIPTION
## Summary

- Add a `receive()` function to `BrickedAxelarGateway` that reverts with `Bricked()`.
- Tighten the native value transfer test to assert the same custom error used by the fallback path.

## Motivation

`BrickedAxelarGateway` is intended to make the gateway permanently unusable after upgrade, with calls reverting through the `Bricked()` custom error. Calls with calldata already hit the fallback and return `Bricked()`, but native value transfers with empty calldata reverted without a reason because there was no payable `receive()` path.

This keeps the bricked behavior consistent for plain native transfers as well.

## Tests

- `npx hardhat test test/BrickedAxelarGateway.js`
- `npm run lint`
- `npm run build`
- `git diff --check`

