### PR TITLE
chore: add changeset for pausable gateway (#318)

### DIFF
--- a/.changeset/pausable-gateway.md
+++ b/.changeset/pausable-gateway.md
@@ -1,0 +1,5 @@
+---
+'@axelar-network/axelar-cgp-solidity': minor
+---
+
+feat: pausable AxelarGateway + BrickedAxelarGateway stub (#318)


### PR DESCRIPTION
#318 added the pausable `AxelarGateway`, the pauser role and `BrickedAxelarGateway`, but merged without a changeset. As a result the feature would not bump the package version at all: `package.json` is still `6.4.0` and the pending release computed from the existing changesets does not account for it.