### PR TITLE
refactor: correct implementation variable spelling

### DIFF
--- a/contracts/AxelarGateway.sol
+++ b/contracts/AxelarGateway.sol
@@ -579,7 +579,7 @@ contract AxelarGateway is IAxelarConsensusGateway, Pausable, Implementation, Ete
     /**
      * @notice Deploys a new token or registers an existing token in the gateway contract itself.
      * @param params Encoded parameters including the token name, symbol, decimals, cap, token address, and mint limit
-     * @dev If the token address is not specified, a new token is deployed and registed as InternalBurnableFrom
+     * @dev If the token address is not specified, a new token is deployed and registered as InternalBurnableFrom
      * @dev If the token address is specified, the token is marked as External.
      * @dev Emits a TokenDeployed event with the symbol and token address.
      */

--- a/contracts/util/Proxy.sol
+++ b/contracts/util/Proxy.sol
@@ -65,12 +65,12 @@ contract Proxy {
 
     // solhint-disable-next-line no-complex-fallback
     fallback() external payable {
-        address implementaion_ = implementation();
+        address implementation_ = implementation();
         // solhint-disable-next-line no-inline-assembly
         assembly {
             calldatacopy(0, 0, calldatasize())
 
-            let result := delegatecall(gas(), implementaion_, 0, calldatasize(), 0, 0)
+            let result := delegatecall(gas(), implementation_, 0, calldatasize(), 0, 0)
             returndatacopy(0, 0, returndatasize())
 
             switch result


### PR DESCRIPTION
Correct two spelling errors in the Solidity sources:

- rename the fallback's local `implementaion_` variable to `implementation_` and update its assembly reference;
- correct “registed” to “registered” in `AxelarGateway` NatSpec.

The local rename does not affect storage, ABI, bytecode control flow, or the address passed to `delegatecall`.

Validation:

    `npx prettier --check contracts/util/Proxy.sol contracts/AxelarGateway.sol`